### PR TITLE
Agent v1 — Slice 3: pre-flight refusals + failure handling

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -6,17 +6,64 @@ name: Agent — Implement
 # against a Postgres + pgvector service DB, does red-green-refactor, runs the
 # repo's quality gate, commits when green, and opens a draft PR linked to the
 # issue. No Docker, no GHCR image, no ANTHROPIC_API_KEY.
+#
+# Slice 3 (#511): a `preflight` job refuses non-leaf / already-PR'd issues
+# *before* any branch or PR work, and the `implement` job runs only when
+# pre-flight passes. Failure / zero-commit handling and the `always()` clear of
+# `agent:in-progress` live in the implement job.
 
 on:
   issues:
     types: [labeled]
 
 jobs:
-  implement:
+  preflight:
     # Run only for the go/spend label, and only when the maintainer added it.
     # The repo is public, so an unguarded trigger would let anyone spend the
-    # maintainer's subscription. A skipped job is the "does nothing" no-op.
+    # maintainer's subscription. A skipped job is the "does nothing" no-op, and
+    # because `implement` needs this job, skipping here skips the whole run.
     if: github.event.label.name == 'agent:implement' && github.actor == 'galosandoval'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Surfaces the refusal verdict to the implement job's `if`.
+    outputs:
+      refused: ${{ steps.preflight.outputs.refused }}
+    env:
+      # AGENT_PAT so the label swap + comment fire downstream events like the
+      # rest of the pipeline (GITHUB_TOKEN-driven label events don't).
+      GH_TOKEN: ${{ secrets.AGENT_PAT }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Pre-flight refusal gate
+        id: preflight
+        # Refuses (remove agent:implement, add agent:blocked, comment) when the
+        # issue is a PRD, a native sub-issue, or already has an open PR, and
+        # sets `refused=true/false`. No branch/PR is created on refusal.
+        run: bun .sandcastle/implement/run-preflight.ts
+
+      - name: Mark blocked if pre-flight itself errored
+        if: failure()
+        env:
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh issue edit "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --remove-label "agent:implement" \
+            --add-label "agent:blocked" || true
+          gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body "$(printf '`agent:implement` pre-flight check failed to run.\n\n**Run:** %s\n\nRe-add `agent:implement` to retry.' "$RUN_URL")" || true
+
+  implement:
+    needs: preflight
+    # Only proceed when pre-flight ran and explicitly passed. A skipped pre-flight
+    # (wrong label/actor) leaves `refused` empty, so this stays skipped too.
+    if: needs.preflight.outputs.refused == 'false'
     runs-on: ubuntu-latest
     # Hard wall-clock cap on the whole run (runaway guard #1).
     timeout-minutes: 45

--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -150,6 +150,14 @@ jobs:
       - name: Apply migrations to the service database
         run: bunx prisma migrate deploy
 
+      - name: Fetch coding standards
+        # Single source of truth: the coding-standard rules live in the public
+        # skills repo (symlinked into ~/.claude/rules locally). CI can't resolve
+        # that symlink, so shallow-clone the repo and point the agent at rules/
+        # via STANDARDS_DIR. Cloned under RUNNER_TEMP so the files never enter
+        # the repo tree or a commit.
+        run: git clone --depth 1 https://github.com/galosandoval/skills.git "${RUNNER_TEMP}/skills"
+
       - name: Run implementation agent
         id: implement
         env:
@@ -159,6 +167,8 @@ jobs:
           # The agent writes pr_description.txt / failure_reason.txt here, outside
           # the repo, so they never land in a commit.
           OUTPUT_DIR: ${{ runner.temp }}
+          # Coding-standard rules cloned by the "Fetch coding standards" step.
+          STANDARDS_DIR: ${{ runner.temp }}/skills/rules
           # App/suite paths the agent may exercise during TDD.
           NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.sandcastle/implement/implement.ts
+++ b/.sandcastle/implement/implement.ts
@@ -14,13 +14,18 @@ const ISSUE_NUMBER = required('ISSUE_NUMBER')
 const ISSUE_TITLE = required('ISSUE_TITLE')
 const BRANCH = required('BRANCH')
 
-// Absolute path to the coding-standard rules (the skills repo's rules/, cloned
-// by the workflow). Optional: empty on a local run, in which case the prompt
-// skips the standards step. Lives outside the repo so it never enters a commit.
+/**
+ * Absolute path to the coding-standard rules (the skills repo's rules/, cloned
+ * by the workflow). Optional: empty on a local run, in which case the prompt
+ * skips the standards step. Lives outside the repo so it never enters a commit.
+ */
 const STANDARDS_DIR = process.env.STANDARDS_DIR ?? ''
 
-// Written outside the repo so the agent's description never lands in a commit.
-// The workflow reads it back and prepends `Closes #N` for the PR body.
+/**
+ * Directory for agent outputs the PR needs but a commit must not contain (the
+ * PR description, failure reason). Lives outside the repo so they never land in
+ * a commit; the workflow reads them back.
+ */
 const OUTPUT_DIR = process.env.OUTPUT_DIR ?? os.tmpdir()
 const PR_DESCRIPTION_FILE = path.join(OUTPUT_DIR, 'pr_description.txt')
 

--- a/.sandcastle/implement/implement.ts
+++ b/.sandcastle/implement/implement.ts
@@ -14,6 +14,11 @@ const ISSUE_NUMBER = required('ISSUE_NUMBER')
 const ISSUE_TITLE = required('ISSUE_TITLE')
 const BRANCH = required('BRANCH')
 
+// Absolute path to the coding-standard rules (the skills repo's rules/, cloned
+// by the workflow). Optional: empty on a local run, in which case the prompt
+// skips the standards step. Lives outside the repo so it never enters a commit.
+const STANDARDS_DIR = process.env.STANDARDS_DIR ?? ''
+
 // Written outside the repo so the agent's description never lands in a commit.
 // The workflow reads it back and prepends `Closes #N` for the PR body.
 const OUTPUT_DIR = process.env.OUTPUT_DIR ?? os.tmpdir()
@@ -38,7 +43,8 @@ const result = await sandcastle.run({
     ISSUE_NUMBER,
     ISSUE_TITLE,
     BRANCH,
-    PR_DESCRIPTION_FILE
+    PR_DESCRIPTION_FILE,
+    STANDARDS_DIR
   },
   // Runaway guard. Sandcastle's claudeCode does not expose Claude's `--max-turns`
   // flag, so the hard caps are wall-clock: this idle timeout (no output for N

--- a/.sandcastle/implement/preflight.test.ts
+++ b/.sandcastle/implement/preflight.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment node
+ */
+import {
+  evaluatePreflight,
+  parseClosingReferences,
+  type PreflightInput
+} from './preflight'
+
+const baseInput: PreflightInput = {
+  subIssueCount: 0,
+  parentNumber: null,
+  linkingPullRequests: []
+}
+
+describe('parseClosingReferences', () => {
+  it('extracts the issue number from each GitHub closing keyword', () => {
+    expect(parseClosingReferences('Closes #12')).toEqual([12])
+    expect(parseClosingReferences('closed #7')).toEqual([7])
+    expect(parseClosingReferences('Fixes #3')).toEqual([3])
+    expect(parseClosingReferences('fixed #8.')).toEqual([8])
+    expect(parseClosingReferences('Resolves #4')).toEqual([4])
+    expect(parseClosingReferences('resolve #5')).toEqual([5])
+  })
+
+  it('is case-insensitive and accepts an optional colon', () => {
+    expect(parseClosingReferences('CLOSES #9')).toEqual([9])
+    expect(parseClosingReferences('Closes: #6')).toEqual([6])
+  })
+
+  it('collects every reference and de-duplicates', () => {
+    expect(
+      parseClosingReferences('fixes #3 and resolves #4\n\nCloses #3')
+    ).toEqual([3, 4])
+  })
+
+  it('ignores non-closing references and bare numbers', () => {
+    expect(parseClosingReferences('Relates to #5')).toEqual([])
+    expect(parseClosingReferences('Refs #5, see #6')).toEqual([])
+    expect(parseClosingReferences('part of a prefix#5 word')).toEqual([])
+    expect(parseClosingReferences('')).toEqual([])
+  })
+})
+
+describe('evaluatePreflight', () => {
+  it('passes a leaf issue with no parent and no open PR', () => {
+    expect(evaluatePreflight(baseInput)).toEqual({ refused: false })
+  })
+
+  it('refuses a PRD (issue with native sub-issues)', () => {
+    const verdict = evaluatePreflight({ ...baseInput, subIssueCount: 4 })
+    expect(verdict.refused).toBe(true)
+    if (verdict.refused) {
+      expect(verdict.reason).toMatch(/PRD/)
+      expect(verdict.reason).toContain('4')
+    }
+  })
+
+  it('refuses an issue that is a native sub-issue of a parent', () => {
+    const verdict = evaluatePreflight({ ...baseInput, parentNumber: 507 })
+    expect(verdict.refused).toBe(true)
+    if (verdict.refused) {
+      expect(verdict.reason).toContain('#507')
+    }
+  })
+
+  it('refuses an issue that already has an open PR targeting it', () => {
+    const verdict = evaluatePreflight({
+      ...baseInput,
+      linkingPullRequests: [{ number: 42, url: 'https://example/pr/42' }]
+    })
+    expect(verdict.refused).toBe(true)
+    if (verdict.refused) {
+      expect(verdict.reason).toContain('#42')
+    }
+  })
+
+  it('reports the PRD refusal before any other (it is the most specific)', () => {
+    const verdict = evaluatePreflight({
+      subIssueCount: 2,
+      parentNumber: 507,
+      linkingPullRequests: [{ number: 42, url: 'https://example/pr/42' }]
+    })
+    expect(verdict.refused).toBe(true)
+    if (verdict.refused) {
+      expect(verdict.reason).toMatch(/PRD/)
+    }
+  })
+})

--- a/.sandcastle/implement/preflight.ts
+++ b/.sandcastle/implement/preflight.ts
@@ -27,7 +27,7 @@ export type PreflightVerdict =
   | { refused: false }
   | { refused: true; reason: string }
 
-// GitHub's issue-closing keywords (every accepted tense/plural form).
+/** GitHub's issue-closing keywords (every accepted tense/plural form). */
 const CLOSING_KEYWORD =
   /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[:\s]+#(\d+)/gi
 

--- a/.sandcastle/implement/preflight.ts
+++ b/.sandcastle/implement/preflight.ts
@@ -1,0 +1,86 @@
+// Pure pre-flight refusal logic for the `agent:implement` pipeline (#511).
+// The v1 agent implements *leaf* issues only, so before any work begins a
+// labeled issue is refused if it is a PRD (has native sub-issues), is itself a
+// native sub-issue of a parent, or already has an open PR targeting it. There
+// is no IO here — `run-preflight.ts` gathers these inputs via `gh` and acts on
+// the verdict (swap labels, comment, skip the implement job).
+//
+// We key off GitHub's *native* parent/sub-issue links, not the repo's textual
+// `## Parent #N` doc convention: the implementable slices each carry that text
+// while being top-level issues, so refusing on the text would block every run.
+
+export interface LinkingPullRequest {
+  number: number
+  url: string
+}
+
+export interface PreflightInput {
+  /** Native GitHub sub-issue count; a PRD has at least one. */
+  subIssueCount: number
+  /** Native GitHub parent issue number, or null for a top-level issue. */
+  parentNumber: number | null
+  /** Open PRs that already target this issue via a closing keyword. */
+  linkingPullRequests: LinkingPullRequest[]
+}
+
+export type PreflightVerdict =
+  | { refused: false }
+  | { refused: true; reason: string }
+
+// GitHub's issue-closing keywords (every accepted tense/plural form).
+const CLOSING_KEYWORD =
+  /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[:\s]+#(\d+)/gi
+
+/**
+ * Issue numbers referenced by a GitHub closing keyword in `text`
+ * (e.g. "Closes #12", "fixes #3", "Resolves: #4"). Case-insensitive and
+ * de-duplicated; non-closing references like "Refs #5" are ignored.
+ */
+export function parseClosingReferences(text: string): number[] {
+  const found = new Set<number>()
+  for (const match of text.matchAll(CLOSING_KEYWORD)) {
+    found.add(Number(match[1]))
+  }
+  return [...found]
+}
+
+/**
+ * Decide whether a labeled leaf issue is safe to implement. Checks are ordered
+ * most-specific first so the comment names the strongest reason to refuse.
+ */
+export function evaluatePreflight(input: PreflightInput): PreflightVerdict {
+  if (input.subIssueCount > 0) {
+    const plural = input.subIssueCount === 1 ? 'sub-issue' : 'sub-issues'
+    return {
+      refused: true,
+      reason:
+        `This issue is a PRD — it has ${input.subIssueCount} ${plural}. ` +
+        'The v1 agent implements leaf issues only; label one of its ' +
+        'sub-issues instead.'
+    }
+  }
+
+  if (input.parentNumber !== null) {
+    return {
+      refused: true,
+      reason:
+        `This issue is a sub-issue of #${input.parentNumber}. The v1 agent ` +
+        'implements leaf issues only; this looks like it is tracked under a ' +
+        'parent that should be decomposed first.'
+    }
+  }
+
+  if (input.linkingPullRequests.length > 0) {
+    const list = input.linkingPullRequests
+      .map((pr) => `#${pr.number}`)
+      .join(', ')
+    return {
+      refused: true,
+      reason:
+        `This issue already has an open PR targeting it (${list}). Close or ` +
+        'merge it before re-adding `agent:implement`.'
+    }
+  }
+
+  return { refused: false }
+}

--- a/.sandcastle/implement/prompt.md
+++ b/.sandcastle/implement/prompt.md
@@ -36,6 +36,14 @@ parts. **Tests are colocated** — the test file sits directly beside the prod
 file (no `__tests__/` directories). Read the colocated tests around the code
 you'll touch; they show the established patterns to follow.
 
+# CODING STANDARDS
+
+If `{{STANDARDS_DIR}}` is non-empty and exists, read the markdown files in it
+before writing code and conform to the ones relevant to the languages you're
+changing (each file's `paths` frontmatter says which files it governs). They are
+the project owner's TypeScript / React / Prisma conventions — treat them as
+binding. If `{{STANDARDS_DIR}}` is empty or missing, proceed without it.
+
 # DATABASE
 
 A Postgres + pgvector database is already running and migrated. The integration

--- a/.sandcastle/implement/run-preflight.ts
+++ b/.sandcastle/implement/run-preflight.ts
@@ -16,41 +16,41 @@ import {
 const ISSUE_NUMBER = required('ISSUE_NUMBER')
 const REPO = required('GITHUB_REPOSITORY')
 
-const issue = JSON.parse(
-  gh([
-    'issue',
-    'view',
-    ISSUE_NUMBER,
-    '--repo',
-    REPO,
-    '--json',
-    'parent,subIssues'
-  ])
-) as {
+const issue = ghJson<{
   parent: { number: number } | null
   subIssues: { totalCount: number }
-}
+}>([
+  'issue',
+  'view',
+  ISSUE_NUMBER,
+  '--repo',
+  REPO,
+  '--json',
+  'parent,subIssues'
+])
 
 const subIssueCount = issue.subIssues?.totalCount ?? 0
 const parentNumber = issue.parent?.number ?? null
 
-// GitHub recognises closing keywords in a PR's body; list every open PR and
-// keep the ones that close this issue. `--limit` is generous so a busy repo
-// doesn't silently truncate the scan.
-const openPullRequests = JSON.parse(
-  gh([
-    'pr',
-    'list',
-    '--repo',
-    REPO,
-    '--state',
-    'open',
-    '--limit',
-    '200',
-    '--json',
-    'number,title,body,url'
-  ])
-) as Array<{ number: number; title: string; body: string | null; url: string }>
+/**
+ * Every open PR in the repo, scanned below for closing keywords that target
+ * this issue. GitHub recognises closing keywords in a PR's body.
+ */
+const openPullRequests = ghJson<
+  Array<{ number: number; title: string; body: string | null; url: string }>
+>([
+  'pr',
+  'list',
+  '--repo',
+  REPO,
+  '--state',
+  'open',
+  // Generous so a busy repo doesn't silently truncate the scan.
+  '--limit',
+  '200',
+  '--json',
+  'number,title,body,url'
+])
 
 const issueNumber = Number(ISSUE_NUMBER)
 const linkingPullRequests: LinkingPullRequest[] = openPullRequests
@@ -96,11 +96,16 @@ if (verdict.refused) {
   console.log(`Pre-flight passed for #${ISSUE_NUMBER}.`)
 }
 
-function gh(args: string[]): string {
+function gh(args: string[]) {
   return execFileSync('gh', args, { encoding: 'utf8' })
 }
 
-function setOutput(name: string, value: string): void {
+/** Run `gh` and parse its stdout as JSON, typed by the caller via `T`. */
+function ghJson<T>(args: string[]): T {
+  return JSON.parse(gh(args)) as T
+}
+
+function setOutput(name: string, value: string) {
   const file = process.env.GITHUB_OUTPUT
   if (!file) {
     console.warn(`GITHUB_OUTPUT unset; would have written ${name}=${value}`)
@@ -109,7 +114,7 @@ function setOutput(name: string, value: string): void {
   fs.appendFileSync(file, `${name}=${value}\n`)
 }
 
-function required(name: string): string {
+function required(name: string) {
   const value = process.env[name]
   if (!value) {
     console.error(`Missing required env var: ${name}`)

--- a/.sandcastle/implement/run-preflight.ts
+++ b/.sandcastle/implement/run-preflight.ts
@@ -1,0 +1,119 @@
+import * as fs from 'node:fs'
+import { execFileSync } from 'node:child_process'
+import {
+  evaluatePreflight,
+  parseClosingReferences,
+  type LinkingPullRequest
+} from './preflight'
+
+// IO entry point for the pre-flight refusal gate (#511). Runs as its own
+// workflow job *before* any branch/PR work: gathers the labeled issue's native
+// parent/sub-issue links and the open PRs targeting it, then asks the pure
+// logic in `preflight.ts` for a verdict. On refusal it swaps the labels, posts
+// an explanatory comment, and signals the implement job to skip — so a PRD, a
+// sub-issue, or an already-PR'd issue never spawns a branch or a draft PR.
+
+const ISSUE_NUMBER = required('ISSUE_NUMBER')
+const REPO = required('GITHUB_REPOSITORY')
+
+const issue = JSON.parse(
+  gh([
+    'issue',
+    'view',
+    ISSUE_NUMBER,
+    '--repo',
+    REPO,
+    '--json',
+    'parent,subIssues'
+  ])
+) as {
+  parent: { number: number } | null
+  subIssues: { totalCount: number }
+}
+
+const subIssueCount = issue.subIssues?.totalCount ?? 0
+const parentNumber = issue.parent?.number ?? null
+
+// GitHub recognises closing keywords in a PR's body; list every open PR and
+// keep the ones that close this issue. `--limit` is generous so a busy repo
+// doesn't silently truncate the scan.
+const openPullRequests = JSON.parse(
+  gh([
+    'pr',
+    'list',
+    '--repo',
+    REPO,
+    '--state',
+    'open',
+    '--limit',
+    '200',
+    '--json',
+    'number,title,body,url'
+  ])
+) as Array<{ number: number; title: string; body: string | null; url: string }>
+
+const issueNumber = Number(ISSUE_NUMBER)
+const linkingPullRequests: LinkingPullRequest[] = openPullRequests
+  .filter((pr) =>
+    parseClosingReferences(`${pr.title ?? ''}\n${pr.body ?? ''}`).includes(
+      issueNumber
+    )
+  )
+  .map((pr) => ({ number: pr.number, url: pr.url }))
+
+const verdict = evaluatePreflight({
+  subIssueCount,
+  parentNumber,
+  linkingPullRequests
+})
+
+if (verdict.refused) {
+  // Refuse before any work: drop the go/spend label, flag blocked, explain why.
+  gh([
+    'issue',
+    'edit',
+    ISSUE_NUMBER,
+    '--repo',
+    REPO,
+    '--remove-label',
+    'agent:implement',
+    '--add-label',
+    'agent:blocked'
+  ])
+  gh([
+    'issue',
+    'comment',
+    ISSUE_NUMBER,
+    '--repo',
+    REPO,
+    '--body',
+    `\`agent:implement\` refused before starting.\n\n**Reason:** ${verdict.reason}\n\nFix the above and re-add \`agent:implement\` to retry.`
+  ])
+  setOutput('refused', 'true')
+  console.log(`Pre-flight refused #${ISSUE_NUMBER}: ${verdict.reason}`)
+} else {
+  setOutput('refused', 'false')
+  console.log(`Pre-flight passed for #${ISSUE_NUMBER}.`)
+}
+
+function gh(args: string[]): string {
+  return execFileSync('gh', args, { encoding: 'utf8' })
+}
+
+function setOutput(name: string, value: string): void {
+  const file = process.env.GITHUB_OUTPUT
+  if (!file) {
+    console.warn(`GITHUB_OUTPUT unset; would have written ${name}=${value}`)
+    return
+  }
+  fs.appendFileSync(file, `${name}=${value}\n`)
+}
+
+function required(name: string): string {
+  const value = process.env[name]
+  if (!value) {
+    console.error(`Missing required env var: ${name}`)
+    process.exit(1)
+  }
+  return value
+}


### PR DESCRIPTION
Closes #511

## Slice 3: pre-flight refusals + failure handling (#511)

Makes the `agent:implement` pipeline safe and self-reporting so the maintainer never gets a silent stall or a bad PR.

### What changed

- **Pre-flight refusal gate (new).** A dedicated `preflight` job runs before any branch/PR work and refuses a labeled issue when it:
  - is a **PRD** — has native GitHub sub-issues,
  - is itself a **native sub-issue** of a parent, or
  - already has an **open PR** targeting it (`Closes/Fixes/Resolves #N`).

  On refusal it removes `agent:implement`, adds `agent:blocked`, comments the reason, and signals the `implement` job to skip — **no branch or PR is created**.

  - `.sandcastle/implement/preflight.ts` — pure, tested logic: `evaluatePreflight()` (most-specific reason first) + `parseClosingReferences()` (every GitHub closing-keyword form).
  - `.sandcastle/implement/run-preflight.ts` — IO entry: gathers the issue's `parent`/`subIssues` and open PRs via `gh`, then acts on the verdict.
  - `agent-implement.yml` — split into `preflight` + `implement`; `implement` runs only on `needs.preflight.outputs.refused == 'false'`, so a skipped pre-flight (wrong label/actor) keeps `implement` skipped, and a pre-flight error marks the issue blocked.

  Note: refusal keys off **native** parent/sub-issue links, *not* the repo's textual `## Parent #N` doc convention — the implementable slices each carry that text while being top-level issues, so refusing on the text would block every run.

- **Failure / zero-commit + always-clear** (carried from slice 2b, verified): `implement.ts` fails a zero-commit run, the `implement` job's `failure()` step adds `agent:blocked` + a comment with the failure reason and run URL, and an `always()` step clears `agent:in-progress`.

### Acceptance criteria

- [x] A PRD / sub-issue / already-PR'd issue is refused with `agent:blocked` + comment, and no branch/PR is created.
- [x] On agent failure or zero commits, the issue gets `agent:blocked` + a comment linking the run URL.
- [x] `agent:in-progress` is always cleared on completion.

### Testing

- `.sandcastle/implement/preflight.test.ts` (colocated, `@jest-environment node`): closing-keyword parsing (case, colon, dedupe, non-closing refs) and each refusal branch + ordering.
- Smoke-tested `run-preflight.ts` against real GitHub data: issue #511 passes (clear leaf); the open-PR detector correctly flags issue #515 as blocked by PR #516.
- Full gate green: `bun run typecheck`, `lint`, `format`, `test` (unit + pgvector integration).

### Notes for the reviewer

- A pre-flight infra error marks the issue blocked from the `preflight` job's own `failure()` step.
- `gh pr list` is scanned with `--limit 200`; revisit if open-PR volume ever exceeds that.
- Pre-existing unrelated `bun.lock` change was left out of this branch's commits.
