### PR TITLE
Rename user-facing "grocery list" to "shopping list" (English copy)

### DIFF
--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -157,7 +157,7 @@
       },
       "list": {
         "title": "List Assistant",
-        "description": "I can help you organize your grocery list and suggest what to buy.",
+        "description": "I can help you organize your shopping list and suggest what to buy.",
         "firstButton": "What am I missing for a balanced meal?",
         "secondButton": "Organize my list by aisle",
         "thirdButton": "Suggest a recipe from my list items"
@@ -224,7 +224,7 @@
     "chatFormPlaceholder": "Ask about a recipe",
     "chatFormContinue": "Follow up with a message or corrections",
     "chatFormRecipeDetail": "Ask about $1",
-    "chatFormList": "Ask about your grocery list",
+    "chatFormList": "Ask about your shopping list",
     "chatFormPantry": "What can I make with what I have?",
     "chatsDrawer": {
       "title": "Recent chats"

--- a/src/constants/chat.test.ts
+++ b/src/constants/chat.test.ts
@@ -32,6 +32,16 @@ describe('buildSystemPrompt', () => {
     expect(prompt).toContain('Carbonara | Margherita Pizza')
   })
 
+  it('describes the list page with "shopping list", honoring the glossary', () => {
+    const prompt = buildSystemPrompt({
+      ...baseArgs,
+      context: { page: 'list' }
+    } as PromptArgs)
+
+    expect(prompt).toContain('shopping list page')
+    expect(prompt).not.toMatch(/grocery list/i)
+  })
+
   describe('hasTasteProfile gate', () => {
     const defaultProfile = {
       cookingSkill: 'intermediate',

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -52,7 +52,7 @@ export const buildSystemPrompt = ({
     contextBlock = parts.join('\n')
   } else if (context?.page === 'list') {
     contextBlock =
-      'The user is on their grocery list page. Help with grocery planning, meal prep, and shopping tips.'
+      'The user is on their shopping list page. Help with meal prep, planning, and shopping tips.'
   } else if (context?.page === 'pantry') {
     contextBlock =
       'The user is on their pantry page. Prefer suggesting recipes that use mainly their pantry ingredients.'


### PR DESCRIPTION
Closes #525

## Rename user-facing "grocery list" → "shopping list" (English copy)

Implements #525.

### What & why
The glossary canonicalizes the user's per-user list of ingredients to buy as **"Shopping List"** and lists "grocery list" under _Avoid_. English copy still said "grocery list", contradicting the ubiquitous language. This is a copy-only rename — no Prisma `List` model, `/list` route, tRPC procedure, or schema changes.

Changed strings:
- `src/constants/chat.ts` — list-page chat system prompt: "grocery list page" → "shopping list page" (also smoothed the trailing sentence to avoid repeating "shopping").
- `public/translations/en.json` (`list.description`) — "organize your grocery list" → "shopping list".
- `public/translations/en.json` (`chatFormList`) — "Ask about your grocery list" → "shopping list".

Spanish (`es.json`) already uses "lista de compras" — untouched. References to external grocery delivery services remain "grocery" (correct, out of scope).

### Acceptance
- `grep -rin "grocery list" src public/translations/en.json` returns nothing (only the new test's assertion regex matches, by design).
- Glossary term "Shopping List" honored in copy.

### Tests
Added a colocated test in `src/constants/chat.test.ts` (red→green) asserting `buildSystemPrompt` with `context.page = 'list'` contains "shopping list page" and no longer matches `/grocery list/i`. Full gate green: typecheck, lint, format, 99 tests pass.

### Notes for reviewer
- Parent #517 (tabbed `/lists` route) is not implemented here; #525 is the leaf copy slice only. Any new copy introduced by #517 should use "shopping list" wording.
