### PR TITLE
PRD: Playwright e2e harness + agent verify phase — browser proof posted to the issue (v2)

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -150,6 +150,17 @@ jobs:
       - name: Apply migrations to the service database
         run: bunx prisma migrate deploy
 
+      - name: Seed the database
+        # The verify phase logs in as the seeded user and asserts populated
+        # state; migrate deploy does not seed, so do it here (same user as the
+        # PR e2e job). Best-effort, like verify itself — never block the run.
+        run: bun run seed || true
+
+      - name: Install Playwright browser
+        # Chromium only, with its OS deps, for the agent's verify phase. Headless
+        # and self-contained on the runner — no Docker, no external browser.
+        run: bunx playwright install --with-deps chromium
+
       - name: Fetch coding standards
         # Single source of truth: the coding-standard rules live in the public
         # skills repo (symlinked into ~/.claude/rules locally). CI can't resolve
@@ -179,6 +190,19 @@ jobs:
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
         run: git push -u origin "$BRANCH"
+
+      - name: Post verify proof to issue
+        # Runs after "Push branch" so the raw URLs resolve against the pushed
+        # branch. Reads the agent's verify report (OUTPUT_DIR) and the committed
+        # screenshots under .agent/verify/issue-<N>/ and posts one issue comment
+        # with the report + PNGs inline. Best-effort: a missing report posts a
+        # "couldn't verify" note rather than failing the run.
+        if: success()
+        env:
+          BRANCH: ${{ steps.branch.outputs.name }}
+          OUTPUT_DIR: ${{ runner.temp }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bun .sandcastle/implement/post-verify-comment.ts || true
 
       - name: Open draft PR
         if: success()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,28 @@ on:
   pull_request:
 
 jobs:
+  # Path filter (#523): decide whether backend code changed, so the e2e job only
+  # pays the build+browser cost on PRs that can break a user flow. Docs/config/
+  # pure-frontend-styling PRs skip it.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Detect backend changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            backend:
+              - 'src/server/**'
+              - 'prisma/**'
+              - 'e2e/**'
+              - 'playwright.config.*'
+
   test:
     runs-on: ubuntu-latest
 
@@ -55,3 +77,82 @@ jobs:
 
       - name: Run tests
         run: bun run test:integration
+
+  # End-to-end gate (#523): build + boot the app against a seeded service DB and
+  # run the Playwright suite. Gated on backend changes via the `changes` job, so
+  # docs/config/pure-styling PRs don't pay the boot+browser cost. Unlike the
+  # agent verify phase, a real misconfig here fails the PR loudly.
+  e2e:
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: recipe_chat_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_PRISMA_URL: postgresql://postgres:postgres@localhost:5432/recipe_chat_test
+      DATABASE_URL_NON_POOLING: postgresql://postgres:postgres@localhost:5432/recipe_chat_test
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/recipe_chat_test
+      PORT: '3000'
+      # Required by env.ts at boot. The seeded login/chat flow doesn't exercise
+      # Stripe/Unsplash, so placeholders satisfy validation without real keys;
+      # the secrets that the flow does touch come from repo secrets.
+      NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      UNSPLASH_ACCESS_KEY: e2e-placeholder
+      STRIPE_SECRET_KEY: e2e-placeholder
+      STRIPE_WEBHOOK_SECRET: e2e-placeholder
+      STRIPE_STARTER_PRICE_ID: e2e-placeholder
+      STRIPE_PREMIUM_PRICE_ID: e2e-placeholder
+      NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: e2e-placeholder
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Generate Prisma client
+        run: bunx prisma generate
+
+      - name: Apply migrations to the test database
+        run: bunx prisma migrate deploy
+
+      - name: Seed the database
+        run: bun run seed
+
+      - name: Install Playwright browser
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run e2e tests
+        run: bun run test:e2e
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,13 @@ next-env.d.ts
 .vscode
 
 .claude/worktrees
+
+# playwright e2e (#523)
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+# the authenticated session fixture: regenerated each run, holds session cookies
+e2e/.auth/
+# local verify-phase screenshots; the agent commits .agent/verify/issue-<N>/ only
+.agent/verify/local/

--- a/.sandcastle/implement/implement.ts
+++ b/.sandcastle/implement/implement.ts
@@ -29,6 +29,15 @@ const STANDARDS_DIR = process.env.STANDARDS_DIR ?? ''
 const OUTPUT_DIR = process.env.OUTPUT_DIR ?? os.tmpdir()
 const PR_DESCRIPTION_FILE = path.join(OUTPUT_DIR, 'pr_description.txt')
 
+/**
+ * Verify-phase report (#523): the agent's markdown verdict on whether the change
+ * was proven in the browser. Written here, outside the repo, like the PR
+ * description; the workflow reads it back and posts it on the issue alongside the
+ * committed screenshots. Best-effort — a run with green implement commits still
+ * succeeds even if verify wrote nothing.
+ */
+const VERIFY_REPORT_FILE = path.join(OUTPUT_DIR, 'verify_report.txt')
+
 const result = await sandcastle.run({
   name: `implement-#${ISSUE_NUMBER}`,
   agent: sandcastle.claudeCode('claude-opus-4-8', {
@@ -49,6 +58,7 @@ const result = await sandcastle.run({
     ISSUE_TITLE,
     BRANCH,
     PR_DESCRIPTION_FILE,
+    VERIFY_REPORT_FILE,
     STANDARDS_DIR
   },
   // Runaway guard. Sandcastle's claudeCode does not expose Claude's `--max-turns`

--- a/.sandcastle/implement/post-verify-comment.ts
+++ b/.sandcastle/implement/post-verify-comment.ts
@@ -1,0 +1,93 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { execFileSync } from 'node:child_process'
+import {
+  buildVerifyComment,
+  verifyScreenshotDir,
+  type VerifyCommentInput
+} from './verify-comment'
+
+// IO entry point for the verify phase's "post proof to the issue" step (#523).
+// Runs after "Push branch" (so the raw URLs resolve) and is `always()`-guarded
+// around the agent: it reads the agent's verify report from OUTPUT_DIR and the
+// screenshots the agent committed under `.agent/verify/issue-<N>/`, then posts a
+// single issue comment with the report and the PNGs rendered inline. The pure
+// markdown/URL assembly lives in `verify-comment.ts` (unit-tested); this file is
+// the GitHub + filesystem edge. Best-effort: a missing report falls back to a
+// "couldn't verify" note so the issue still records that verify ran.
+
+const ISSUE_NUMBER = required('ISSUE_NUMBER')
+const REPO = required('GITHUB_REPOSITORY')
+const BRANCH = required('BRANCH')
+const RUN_URL = required('RUN_URL')
+
+const OUTPUT_DIR = process.env.OUTPUT_DIR ?? os.tmpdir()
+const VERIFY_REPORT_FILE =
+  process.env.VERIFY_REPORT_FILE ?? path.join(OUTPUT_DIR, 'verify_report.txt')
+
+const issueNumber = Number(ISSUE_NUMBER)
+
+const report = readReport()
+const screenshots = listCommittedScreenshots(issueNumber)
+
+const input: VerifyCommentInput = {
+  report,
+  repo: REPO,
+  branch: BRANCH,
+  issueNumber,
+  screenshots,
+  runUrl: RUN_URL
+}
+
+const body = buildVerifyComment(input)
+gh(['issue', 'comment', ISSUE_NUMBER, '--repo', REPO, '--body', body])
+console.log(
+  `Posted verify comment to #${ISSUE_NUMBER} (${screenshots.length} screenshot(s)).`
+)
+
+/** The agent's report, or a fallback note when verify produced none. */
+function readReport(): string {
+  try {
+    const text = fs.readFileSync(VERIFY_REPORT_FILE, 'utf8').trim()
+    if (text.length > 0) return text
+  } catch {
+    // fall through to the fallback note
+  }
+  return (
+    "**Verification couldn't complete.** The agent did not write a verify " +
+    'report this run — check the workflow logs and verify the change manually.'
+  )
+}
+
+/**
+ * Repo-relative paths of the PNGs the agent committed for this issue, sorted for
+ * a stable comment order. Empty when the directory is absent (non-UI issue or a
+ * verify run that captured nothing).
+ */
+function listCommittedScreenshots(issue: number): string[] {
+  const dir = verifyScreenshotDir(issue)
+  let entries: string[]
+  try {
+    entries = fs.readdirSync(dir)
+  } catch {
+    return []
+  }
+  return entries
+    .filter((name) => /\.(png|jpe?g|gif|webp)$/i.test(name))
+    .sort()
+    .map((name) => `${dir}/${name}`)
+}
+
+function gh(args: string[]) {
+  return execFileSync('gh', args, { encoding: 'utf8' })
+}
+
+function required(name: string): string {
+  const value = process.env[name]
+  if (!value) {
+    console.error(`Missing required env var: ${name}`)
+    process.exit(1)
+  }
+  return value
+}

--- a/.sandcastle/implement/prompt.md
+++ b/.sandcastle/implement/prompt.md
@@ -82,6 +82,47 @@ Make one or more commits on `{{BRANCH}}` with conventional-commit messages
 (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`). Keep commits
 focused. Do not amend or force-push; just add commits.
 
+# VERIFY — prove it works in the browser (best-effort, never blocks)
+
+After your green-gate commits, before writing the PR description, prove the
+change works for a user. This phase is **best-effort**: if anything here fails,
+capture what you can, write the report, and move on — never let verify fail the
+run or discard your implementation commits.
+
+1. **Judge UI-verifiability.** From the issue's acceptance criteria, decide
+   whether this change is observable in the running app (a screen renders, an
+   interaction works). Backend-only, infra, or tooling changes are **not**
+   UI-verifiable.
+
+2. **If NOT UI-verifiable:** skip the browser work entirely. Write a short report
+   to `{{VERIFY_REPORT_FILE}}` saying so — e.g. "Not UI-verifiable (backend-only);
+   verified via the unit/integration suite." Do not capture screenshots. Done.
+
+3. **If UI-verifiable:**
+   - Write (or extend) a **durable Playwright spec** under `e2e/` that exercises
+     the issue's user flow. This is a real, lasting regression test — not a
+     throwaway. Use the shared auth fixture (`storageState`) and `webServer` boot
+     from `playwright.config.ts`; do **not** re-script login or app boot. Follow
+     the pattern in `e2e/chat.spec.ts` and capture the final state of each
+     user-facing acceptance criterion with `page.screenshot()` into the verify
+     directory via `screenshotPath(...)` from `e2e/verify.ts` (it resolves to
+     `.agent/verify/issue-{{ISSUE_NUMBER}}/` when `VERIFY_ISSUE` is set).
+   - Run it: `VERIFY_ISSUE={{ISSUE_NUMBER}} bun run test:e2e`. Playwright builds +
+     boots the app against the seeded DB and captures the screenshots.
+   - **Commit** the new/updated spec under `e2e/` **and** the PNGs under
+     `.agent/verify/issue-{{ISSUE_NUMBER}}/` onto the branch (they need to be
+     committed so the workflow can render them inline via raw URLs).
+   - Write a short report to `{{VERIFY_REPORT_FILE}}`: what flow you checked, the
+     verdict, and one line per screenshot mapping it to an acceptance criterion.
+
+4. **If the browser run errors** (app won't boot, spec throws): capture whatever
+   evidence you can (a failure-state screenshot if the page loaded at all),
+   commit it, and write a report explaining what failed and why. Do not fail the
+   run.
+
+The `{{VERIFY_REPORT_FILE}}` lives outside the repo (like the PR description);
+the workflow reads it back and posts it on the issue with the screenshots inline.
+
 # FINAL STEP — write the PR description
 
 As the very last thing, write a short PR description (plain markdown) to the

--- a/.sandcastle/implement/verify-comment.test.ts
+++ b/.sandcastle/implement/verify-comment.test.ts
@@ -1,0 +1,82 @@
+/**
+ * @jest-environment node
+ */
+import {
+  buildVerifyComment,
+  rawScreenshotUrl,
+  verifyScreenshotDir,
+  type VerifyCommentInput
+} from './verify-comment'
+
+const baseInput: VerifyCommentInput = {
+  report: 'Verified the login flow.',
+  repo: 'galosandoval/recipe-chat',
+  branch: 'agent/issue-5-add-login',
+  issueNumber: 5,
+  screenshots: [],
+  runUrl: 'https://github.com/galosandoval/recipe-chat/actions/runs/123'
+}
+
+describe('verifyScreenshotDir', () => {
+  it('names the per-issue screenshots directory', () => {
+    expect(verifyScreenshotDir(5)).toBe('.agent/verify/issue-5')
+    expect(verifyScreenshotDir(523)).toBe('.agent/verify/issue-523')
+  })
+})
+
+describe('rawScreenshotUrl', () => {
+  it('builds a raw.githubusercontent.com URL for a committed path', () => {
+    expect(
+      rawScreenshotUrl(
+        'galosandoval/recipe-chat',
+        'agent/issue-5-add-login',
+        '.agent/verify/issue-5/login.png'
+      )
+    ).toBe(
+      'https://raw.githubusercontent.com/galosandoval/recipe-chat/agent/issue-5-add-login/.agent/verify/issue-5/login.png'
+    )
+  })
+
+  it('percent-encodes each path segment but keeps the slashes', () => {
+    expect(
+      rawScreenshotUrl('o/r', 'main', '.agent/verify/issue-5/final state.png')
+    ).toBe(
+      'https://raw.githubusercontent.com/o/r/main/.agent/verify/issue-5/final%20state.png'
+    )
+  })
+})
+
+describe('buildVerifyComment', () => {
+  it('includes the trimmed report and a link to the workflow run', () => {
+    const comment = buildVerifyComment({
+      ...baseInput,
+      report: '\n  Verified the login flow.  \n'
+    })
+    expect(comment).toContain('Verified the login flow.')
+    expect(comment).not.toMatch(/^\s/) // report leads, no leading whitespace
+    expect(comment).toContain(`[workflow run](${baseInput.runUrl})`)
+  })
+
+  it('omits the screenshots section when there are none', () => {
+    const comment = buildVerifyComment(baseInput)
+    expect(comment).not.toContain('Screenshots')
+    expect(comment).not.toContain('![')
+  })
+
+  it('renders each screenshot inline by its raw URL with a filename alt', () => {
+    const comment = buildVerifyComment({
+      ...baseInput,
+      screenshots: [
+        '.agent/verify/issue-5/login.png',
+        '.agent/verify/issue-5/chat.png'
+      ]
+    })
+    expect(comment).toContain('Screenshots')
+    expect(comment).toContain(
+      '![login.png](https://raw.githubusercontent.com/galosandoval/recipe-chat/agent/issue-5-add-login/.agent/verify/issue-5/login.png)'
+    )
+    expect(comment).toContain(
+      '![chat.png](https://raw.githubusercontent.com/galosandoval/recipe-chat/agent/issue-5-add-login/.agent/verify/issue-5/chat.png)'
+    )
+  })
+})

--- a/.sandcastle/implement/verify-comment.ts
+++ b/.sandcastle/implement/verify-comment.ts
@@ -1,0 +1,73 @@
+// Pure helpers for the `agent:implement` verify phase (#523). The verify phase
+// captures Playwright screenshots into `.agent/verify/issue-<N>/`, commits them
+// to the PR branch, and the workflow posts them back on the originating issue as
+// inline proof. These functions turn (repo, branch, issue, screenshot paths,
+// report) into the markdown comment body and the raw URLs that render the PNGs
+// inline. No IO here — `post-verify-comment.ts` reads the committed directory
+// and calls `gh issue comment`; this module is the unit-testable seam.
+
+/** Repo-relative directory the verify phase commits its screenshots into. */
+export function verifyScreenshotDir(issueNumber: number): string {
+  return `.agent/verify/issue-${issueNumber}`
+}
+
+/**
+ * Raw URL for a committed file, so the issue comment renders it inline without
+ * an artifact download. Each path segment is percent-encoded (filenames may
+ * contain spaces) while the slashes are preserved.
+ */
+export function rawScreenshotUrl(
+  repo: string,
+  branch: string,
+  repoRelativePath: string
+): string {
+  const encodedPath = repoRelativePath
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/')
+  return `https://raw.githubusercontent.com/${repo}/${branch}/${encodedPath}`
+}
+
+export interface VerifyCommentInput {
+  /** Agent's markdown verify report (verdict + what was checked). */
+  report: string
+  /** "owner/name", e.g. "galosandoval/recipe-chat". */
+  repo: string
+  /** Branch the screenshots were committed to (raw URLs resolve against it). */
+  branch: string
+  /** Issue being verified. */
+  issueNumber: number
+  /** Repo-relative paths of committed screenshots; empty for non-UI issues. */
+  screenshots: string[]
+  /** URL of the workflow run, for a "jump to logs" link. */
+  runUrl: string
+}
+
+/** Basename of a path, used as the image alt text. */
+function basename(p: string): string {
+  const parts = p.split('/')
+  return parts[parts.length - 1] ?? p
+}
+
+/**
+ * Assemble the single issue comment: the agent's report, the screenshots
+ * rendered inline (omitted entirely when there are none, e.g. a backend-only
+ * issue), and a link to the workflow run for the full logs.
+ */
+export function buildVerifyComment(input: VerifyCommentInput): string {
+  const sections = [input.report.trim()]
+
+  if (input.screenshots.length > 0) {
+    const images = input.screenshots
+      .map((path) => {
+        const url = rawScreenshotUrl(input.repo, input.branch, path)
+        return `![${basename(path)}](${url})`
+      })
+      .join('\n\n')
+    sections.push(`### Screenshots\n\n${images}`)
+  }
+
+  sections.push(`[workflow run](${input.runUrl})`)
+
+  return sections.join('\n\n')
+}

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -75,3 +75,9 @@ _Avoid_: plan, level
 **Onboarding Step**:
 A discrete milestone in the new-user onboarding tour that has been completed (e.g. first generated chat, first saved recipe). Distinct from tier-gated features.
 _Avoid_: feature, tour step, flag
+
+## Testing conventions
+
+Unit and integration tests are **colocated** — the test file sits directly beside the prod file it covers (no `__tests__/` directories). Backend/Node tests carry the `@jest-environment node` docblock.
+
+**Exception — `e2e/`**: end-to-end Playwright specs live in a top-level `e2e/` directory, not beside a prod file, because they span features rather than covering one module. They run via `bun run test:e2e` and are **not** part of the default `bun run test` gate. See `docs/agents/e2e-and-verify.md`.

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "recipe-chat",
@@ -57,6 +58,7 @@
       "devDependencies": {
         "@ai-hero/sandcastle": "0.10.0",
         "@hookform/resolvers": "^3.10.0",
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/typography": "^0.5.16",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.8.0",
@@ -384,6 +386,8 @@
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
+
+    "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
 
     "@prisma/client": ["@prisma/client@6.18.0", "", { "peerDependencies": { "prisma": "*", "typescript": ">=5.1.0" } }, "sha512-jnL2I9gDnPnw4A+4h5SuNn8Gc+1mL1Z79U/3I9eE2gbxJG1oSA+62ByPW4xkeDgwE0fqMzzpAZ7IHxYnLZ4iQA=="],
 
@@ -1029,7 +1033,7 @@
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -1493,6 +1497,10 @@
 
     "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
 
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
+
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
+
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
     "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
@@ -1924,6 +1932,8 @@
     "jest-diff/pretty-format": ["pretty-format@30.0.5", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw=="],
 
     "jest-each/pretty-format": ["pretty-format@30.0.5", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw=="],
+
+    "jest-haste-map/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "jest-leak-detector/pretty-format": ["pretty-format@30.0.5", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw=="],
 

--- a/docs/agents/e2e-and-verify.md
+++ b/docs/agents/e2e-and-verify.md
@@ -1,0 +1,67 @@
+# Playwright e2e harness + agent verify phase
+
+The end-to-end harness and the `agent:implement` **verify phase** (PRD: #523).
+The harness is the foundation; the verify phase is built on top of it. Screenshots
+are a side effect of running a real, durable test — not a throwaway script.
+
+## The harness
+
+- **`playwright.config.ts`** (repo root) — a `webServer` block that builds + boots
+  the app (`bun run build && bun run start`) and waits for it, a base URL, screenshot/
+  trace/video capture, and two projects: a `setup` project that logs in once and a
+  `chromium` project that reuses that session.
+- **`e2e/`** (top-level) — the specs. A deliberate, documented exception to the
+  repo's "tests are colocated, no `__tests__/`" convention, because e2e specs span
+  features. See the note in `CONTEXT.md`.
+  - `e2e/auth.setup.ts` — logs in as the seeded user (`alice@prisma.io` /
+    `Admin@123` from `prisma/seed.ts`) and saves `storageState` to
+    `e2e/.auth/user.json` (gitignored).
+  - `e2e/verify.ts` — `verifyDir()` / `screenshotPath()`, which resolve to
+    `.agent/verify/issue-<N>/` when `VERIFY_ISSUE` is set (else `.agent/verify/local/`).
+  - `e2e/chat.spec.ts` — example authenticated spec and the template the agent follows.
+- **Scripts** — `bun run test:e2e` (and `test:e2e:ui`). **Not** part of the default
+  `bun run test` gate, so the unit/integration loop stays fast and the agent's
+  per-commit loop never boots a browser.
+
+Run locally: `bun run seed` (once, against your dev DB), then `bun run test:e2e`.
+
+## The verify phase (`agent:implement`)
+
+Appended to the existing `implement` job in `.github/workflows/agent-implement.yml`,
+after the green-gate commits and before the draft PR. It reuses the implement
+phase's isolation, service DB, and token model — no new job, label, or secret.
+
+The workflow adds (before the agent) a `bun run seed` step and a
+`bunx playwright install --with-deps chromium` step. The agent's `prompt.md` gains
+a VERIFY section: it judges UI-verifiability from the acceptance criteria, and if
+UI-verifiable, writes a durable `e2e/` spec, runs `VERIFY_ISSUE=<N> bun run test:e2e`,
+commits the spec + the PNGs under `.agent/verify/issue-<N>/`, and writes a verify
+report to `OUTPUT_DIR/verify_report.txt`. Backend-only issues skip the browser work
+and the report says so.
+
+After **Push branch** (so raw URLs resolve), the workflow runs
+`.sandcastle/implement/post-verify-comment.ts`, which reads the report + the committed
+screenshots and posts a single issue comment with the PNGs rendered inline and a link
+to the workflow run. The markdown/URL assembly is the pure, unit-tested
+`verify-comment.ts` (`verify-comment.test.ts`); `gh` and the filesystem stay at the edge.
+
+**Best-effort, never fatal.** Verify never fails the implement run: a missing report
+posts a "couldn't verify" note, and green implement commits still ship.
+
+## CI gate
+
+`.github/workflows/test.yml` has a path-filtered `e2e` job (via `dorny/paths-filter`)
+that runs only when backend code changed — `src/server/**`, `prisma/**`, `e2e/**`,
+`playwright.config.*`. It seeds the DB, installs Chromium, and runs `test:e2e`. Unlike
+the agent verify phase, a real misconfig here fails the PR loudly. PRs touching only
+docs, config, or pure-frontend styling skip it.
+
+## Trade-offs / follow-ups
+
+- **Committed PNGs** under `.agent/verify/issue-<N>/` merge into `main` unless stripped
+  before merge (clearly named so they're trivial to drop in a squash). Hosting them
+  off-repo is a follow-up.
+- The durable `e2e/` spec is **meant** to stay — that's the lasting-value difference
+  from a throwaway script.
+- Single headless Chromium at a default viewport; no cross-browser/responsive matrix,
+  no visual regression / pixel diffing.

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,0 +1,30 @@
+import { test as setup, expect } from '@playwright/test'
+import { STORAGE_STATE } from '../playwright.config'
+
+// Shared auth fixture (#523). Logs in once as the seeded user and saves the
+// session to STORAGE_STATE; the `chromium` project loads that state so every
+// spec runs as a genuine authenticated session without re-scripting login.
+//
+// The seeded user comes from `prisma/seed.ts` (`bun run seed`), which both the
+// verify phase and the PR `e2e` job run against the service DB before this.
+const SEEDED_USER = {
+  email: process.env.E2E_USER_EMAIL ?? 'alice@prisma.io',
+  password: process.env.E2E_USER_PASSWORD ?? 'Admin@123'
+}
+
+setup('authenticate as the seeded user', async ({ page }) => {
+  await page.goto('/')
+
+  // The unauthenticated chat welcome surfaces a "Login" link that opens the
+  // login drawer/dialog.
+  await page.getByRole('button', { name: 'Login' }).click()
+
+  await page.getByLabel('Email').fill(SEEDED_USER.email)
+  await page.getByLabel('Password').fill(SEEDED_USER.password)
+  await page.getByRole('button', { name: 'Login' }).last().click()
+
+  // A successful login routes to /chat; wait for it before saving the session.
+  await page.waitForURL('**/chat')
+
+  await page.context().storageState({ path: STORAGE_STATE })
+})

--- a/e2e/chat.spec.ts
+++ b/e2e/chat.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test'
+import { screenshotPath } from './verify'
+
+// Example durable e2e spec (#523) — also the template the agent's verify phase
+// follows: navigate as the authenticated seeded user, assert on what the user
+// sees, and capture the final state into `.agent/verify/issue-<N>/` as proof.
+// It uses the shared auth fixture (storageState), so it never re-scripts login.
+test.describe('authenticated chat', () => {
+  test('the seeded user lands on the chat screen', async ({ page }) => {
+    await page.goto('/chat')
+
+    // The message composer is the always-present anchor of the chat screen.
+    const composer = page.getByRole('textbox')
+    await expect(composer.first()).toBeVisible()
+
+    await page.screenshot({
+      path: screenshotPath('chat.png'),
+      fullPage: true
+    })
+  })
+})

--- a/e2e/verify.ts
+++ b/e2e/verify.ts
@@ -1,0 +1,20 @@
+import * as path from 'node:path'
+
+// Shared helper for verify-phase specs (#523). The agent's spec captures the
+// final state of each user-facing acceptance criterion into
+// `.agent/verify/issue-<N>/`; the workflow commits that directory and posts the
+// PNGs inline on the originating issue. `VERIFY_ISSUE` is set by the agent's
+// verify run; locally it falls back to a `local` directory so a human can run
+// the same spec without an issue number.
+const VERIFY_ROOT = '.agent/verify'
+
+/** Directory the current verify run writes its screenshots into. */
+export function verifyDir(): string {
+  const issue = process.env.VERIFY_ISSUE
+  return path.join(VERIFY_ROOT, issue ? `issue-${issue}` : 'local')
+}
+
+/** Absolute-within-repo path for a named screenshot in the verify directory. */
+export function screenshotPath(name: string): string {
+  return path.join(verifyDir(), name)
+}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -17,6 +17,9 @@ const config: Config = {
   },
   // Ignore nested worktree copies so Haste doesn't see duplicate package.json.
   modulePathIgnorePatterns: ['<rootDir>/.claude/worktrees/'],
+  // Playwright owns the top-level `e2e/` specs; keep Jest out of them so the
+  // unit/integration gate never tries to run a browser spec (#523).
+  testPathIgnorePatterns: ['/node_modules/', '<rootDir>/e2e/'],
   // Only treat *.test/*.spec files as suites, so test helpers can live in
   // __tests__ dirs without being mistaken for empty test files.
   testMatch: ['**/?(*.)+(spec|test).[jt]s?(x)'],

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "test:unit": "bunx jest --testPathIgnorePatterns node_modules src/server/api",
     "test:integration": "bunx jest src/server/api",
     "test:watch": "bunx jest --watch",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "test:db:setup": "dotenv -e .env.test.local -- prisma migrate deploy",
     "data-migration:add-saved-column": "tsx ./prisma/migrations/20250730012052_add_saved_column/data-migration.ts",
     "data-migration:create-many-recipes-to-many-messages-table": "tsx ./prisma/migrations/20250730020516_create_many_recipes_to_many_messages_table/data-migration.ts",
@@ -89,6 +91,7 @@
   "devDependencies": {
     "@ai-hero/sandcastle": "0.10.0",
     "@hookform/resolvers": "^3.10.0",
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/typography": "^0.5.16",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.8.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,61 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// Playwright e2e harness (#523). This is the project's first-class end-to-end
+// test runner — not a throwaway script. The agent's verify phase and the
+// path-filtered PR `e2e` job both run it via `bun run test:e2e`. It is kept out
+// of the default `bun run test` gate so the unit/integration loop stays fast and
+// never boots a browser.
+//
+// Specs live in the top-level `e2e/` directory — a deliberate, documented
+// exception to the repo's "tests are colocated, no `__tests__/`" convention,
+// because e2e specs span features rather than sitting beside one prod file.
+
+const PORT = Number(process.env.PORT ?? 3000)
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${PORT}`
+
+// Authenticated session, produced once by the `setup` project and reused across
+// specs so each spec exercises a genuine logged-in session without re-scripting
+// login. Gitignored — it holds session cookies and is regenerated each run.
+export const STORAGE_STATE = 'e2e/.auth/user.json'
+
+export default defineConfig({
+  testDir: './e2e',
+  // Proof is a side effect of running a real test: capture on, traces/video on
+  // failure so a flaky boot still leaves evidence behind.
+  use: {
+    baseURL,
+    screenshot: 'on',
+    trace: 'on-first-retry',
+    video: 'retain-on-failure'
+  },
+  // A little flake tolerance in CI; none locally so failures are loud.
+  retries: process.env.CI ? 1 : 0,
+  // Be patient: app boot + browser is slow on a cold CI runner.
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /.*\.setup\.ts/
+    },
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], storageState: STORAGE_STATE },
+      dependencies: ['setup']
+    }
+  ],
+
+  // Build + boot the app and wait for it to answer, so a local/CI `test:e2e`
+  // run is one command against the seeded service DB.
+  webServer: {
+    command: 'bun run build && bun run start',
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    // The build dominates this; keep it generous for a cold runner.
+    timeout: 180_000,
+    stdout: 'pipe',
+    stderr: 'pipe'
+  }
+})


### PR DESCRIPTION
Closes #523

## What & why

Implements #523 — a first-class Playwright e2e harness plus the `agent:implement` **verify phase** that proves a change works in the browser and posts the proof back on the issue.

### Harness (foundation)
- `@playwright/test` devDep + `playwright.config.ts`: `webServer` builds + boots the app, base URL, screenshot/trace/video capture, a `setup` project that logs in once as the seeded user and a `chromium` project that reuses that `storageState`.
- Top-level `e2e/` dir (documented exception to the colocated-tests convention): `auth.setup.ts` (shared auth fixture), `verify.ts` (`.agent/verify/issue-<N>/` path helper), and an example `chat.spec.ts` that doubles as the agent's template.
- `test:e2e` / `test:e2e:ui` scripts, kept **out** of the default `bun run test` gate; Jest configured to ignore `e2e/`; auth state + local screenshots gitignored.

### Verify phase (agent)
- `prompt.md` VERIFY section: judge UI-verifiability, write a durable `e2e/` spec, run `test:e2e` capturing screenshots into `.agent/verify/issue-<N>/`, commit spec + PNGs, write a verify report. Backend-only issues skip the browser and say so. Best-effort — never fails the run.
- `implement.ts` passes `VERIFY_REPORT_FILE` (outside the repo, like `pr_description.txt`).
- `verify-comment.ts` (pure) builds the issue comment with inline raw-URL images; `post-verify-comment.ts` is the `gh`/filesystem edge.
- `agent-implement.yml`: seed + Chromium install before the agent; after Push branch, post the report + inline screenshots on the issue (best-effort `|| true`).

### CI gate
- `test.yml`: a `dorny/paths-filter` `changes` job gates a new `e2e` job on backend changes (`src/server/**`, `prisma/**`, `e2e/**`, `playwright.config.*`) — seeds, installs Chromium, runs `test:e2e`, uploads the report. Fails loudly on real misconfig; docs/styling PRs skip it.

## How it's tested
- New `verify-comment.test.ts` (colocated, `@jest-environment node`) pins the pure URL/markdown helper via TDD: per-issue dir naming, raw-URL building + percent-encoding, comment assembly, and the no-screenshots (backend-only) path. All 110 Jest tests pass; `bunx playwright test --list` confirms both projects wire up.
- The harness/workflow surface is YAML + prompt + a generated spec; per the PRD its real verification is the end-to-end dry run (label a UI issue vs. a backend-only issue), which can't run inside this gate.

## Reviewer notes
- **Trade-off:** PNGs under `.agent/verify/issue-<N>/` merge into `main` unless stripped before merge (clearly named, easy to drop in a squash). Off-repo hosting is a noted follow-up.
- **App-boot risk:** booting depends on full env. The PR `e2e` job sets placeholders for Stripe/Unsplash (the seeded login/chat flow doesn't touch them) and uses repo secrets for `NEXTAUTH_SECRET` / `OPENAI_API_KEY`; the agent verify phase is best-effort so a missing env surfaces as a "couldn't verify" comment.
- Reverted unrelated prettier drift in `README.md` to keep the diff focused.
