### PR TITLE
fix #523 enhance project setup with Playwright e2e testing and verifi…

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -179,6 +179,10 @@ jobs:
           # App/suite paths the agent may exercise during TDD.
           NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          # The verify phase boots the same `next start` production build, so
+          # Auth.js would reject the untrusted host and break the e2e login the
+          # same way the PR e2e gate would. Trust the host explicitly here too.
+          AUTH_TRUST_HOST: true
         run: bun .sandcastle/implement/implement.ts
 
       - name: Push branch

--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -150,6 +150,13 @@ jobs:
       - name: Apply migrations to the service database
         run: bunx prisma migrate deploy
 
+      - name: Install Playwright browser
+        # The agent's VERIFY phase runs `bun run test:e2e` (headless Chromium)
+        # against the booted app. Install the browser + OS deps here so the
+        # agent doesn't need sudo. --with-deps is a no-op on an already-set-up
+        # runner but keeps this self-contained (no Docker, no browser service).
+        run: bunx playwright install --with-deps chromium
+
       - name: Fetch coding standards
         # Single source of truth: the coding-standard rules live in the public
         # skills repo (symlinked into ~/.claude/rules locally). CI can't resolve
@@ -175,10 +182,26 @@ jobs:
         run: bun .sandcastle/implement/implement.ts
 
       - name: Push branch
+        id: push_branch
         if: success()
         env:
           BRANCH: ${{ steps.branch.outputs.name }}
         run: git push -u origin "$BRANCH"
+
+      - name: Post verify proof to the issue
+        # Runs whenever the branch was pushed (so raw.githubusercontent URLs
+        # resolve), regardless of any later step's status: read the agent's
+        # verify report, enumerate the committed screenshots under
+        # .agent/verify/issue-<N>/, and post one issue comment with the report +
+        # inline images + a run link. Best-effort — the script swallows errors,
+        # and the agent's verify phase never fails its step, so a verify hiccup
+        # still yields a comment and never loses the green implement commits.
+        if: steps.push_branch.outcome == 'success'
+        env:
+          BRANCH: ${{ steps.branch.outputs.name }}
+          OUTPUT_DIR: ${{ runner.temp }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: bun .sandcastle/implement/post-verify.ts
 
       - name: Open draft PR
         if: success()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,3 +55,96 @@ jobs:
 
       - name: Run tests
         run: bun run test:integration
+
+  # Detects whether a change touches backend surfaces, so the e2e gate (which
+  # boots the app + a browser) only pays its cost when user-facing behavior
+  # could have changed. Docs/config/pure-styling PRs skip e2e.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Detect backend changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            backend:
+              - 'src/server/**'
+              - 'prisma/**'
+              - 'e2e/**'
+              - 'playwright.config.*'
+
+  # Playwright e2e gate (#523). Runs only when backend code changed. Single
+  # headless Chromium, self-contained on the runner — no Docker, no GHCR image,
+  # no external browser service.
+  e2e:
+    needs: changes
+    if: needs.changes.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: recipe_chat_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_PRISMA_URL: postgresql://postgres:postgres@localhost:5432/recipe_chat_test
+      DATABASE_URL_NON_POOLING: postgresql://postgres:postgres@localhost:5432/recipe_chat_test
+      # The built app needs these at boot; a real misconfig here should fail the
+      # e2e job loudly (unlike the agent's best-effort verify phase).
+      NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Generate Prisma client
+        run: bunx prisma generate
+
+      - name: Apply migrations to the test database
+        run: bunx prisma migrate deploy
+
+      - name: Seed the database
+        # The auth fixture logs in as the seeded user; login + populated-state
+        # assertions need it present. No integration suite runs here to truncate.
+        run: bun run seed
+
+      - name: Install Playwright browser
+        run: bunx playwright install --with-deps chromium
+
+      - name: Run e2e tests
+        run: bun run test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,6 +108,11 @@ jobs:
       # e2e job loudly (unlike the agent's best-effort verify phase).
       NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      # `next start` (production) makes Auth.js reject any request whose host
+      # isn't trusted, so every /api/auth/session call 500s and the auth fixture
+      # never reaches /chat. Dev and Vercel auto-trust the host; a bare runner
+      # does not — opt in explicitly so the e2e login works.
+      AUTH_TRUST_HOST: true
 
     steps:
       - name: Checkout repo

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,11 @@ next-env.d.ts
 .vscode
 
 .claude/worktrees
+
+# playwright e2e (artifacts + the auth storageState are regenerated each run;
+# the committed proof under .agent/verify/ is intentionally NOT ignored)
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+/e2e/.auth/

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,6 @@
+# Format staged files (prettier --write via lint-staged), then typecheck the
+# project. Keeps formatting/type errors out of commits — including the agent's
+# per-commit loop — before the green gate even runs. Deliberately omits tests
+# (CI/agent gate holds those) to keep commits fast.
+bunx lint-staged
+bun run typecheck

--- a/.sandcastle/implement/implement.ts
+++ b/.sandcastle/implement/implement.ts
@@ -30,13 +30,16 @@ const OUTPUT_DIR = process.env.OUTPUT_DIR ?? os.tmpdir()
 const PR_DESCRIPTION_FILE = path.join(OUTPUT_DIR, 'pr_description.txt')
 
 /**
- * Verify-phase outputs (#523), passed to the prompt like PR_DESCRIPTION_FILE.
- * VERIFY_REPORT_FILE lives in OUTPUT_DIR (outside the repo — never committed);
- * the workflow's post-verify step reads it back. SCREENSHOTS_DIR is a
- * repo-relative path the agent commits PNGs into, so they get raw URLs for
- * inline rendering in the issue comment.
+ * Verify-phase report (#523), passed to the prompt like PR_DESCRIPTION_FILE.
+ * Lives in OUTPUT_DIR (outside the repo — never committed); the workflow's
+ * post-verify step reads it back.
  */
 const VERIFY_REPORT_FILE = path.join(OUTPUT_DIR, 'verify_report.md')
+
+/**
+ * Verify-phase screenshots dir (#523), a repo-relative path the agent commits
+ * PNGs into, so they get raw URLs for inline rendering in the issue comment.
+ */
 const SCREENSHOTS_DIR = `.agent/verify/issue-${ISSUE_NUMBER}`
 
 const result = await sandcastle.run({

--- a/.sandcastle/implement/implement.ts
+++ b/.sandcastle/implement/implement.ts
@@ -29,6 +29,16 @@ const STANDARDS_DIR = process.env.STANDARDS_DIR ?? ''
 const OUTPUT_DIR = process.env.OUTPUT_DIR ?? os.tmpdir()
 const PR_DESCRIPTION_FILE = path.join(OUTPUT_DIR, 'pr_description.txt')
 
+/**
+ * Verify-phase outputs (#523), passed to the prompt like PR_DESCRIPTION_FILE.
+ * VERIFY_REPORT_FILE lives in OUTPUT_DIR (outside the repo — never committed);
+ * the workflow's post-verify step reads it back. SCREENSHOTS_DIR is a
+ * repo-relative path the agent commits PNGs into, so they get raw URLs for
+ * inline rendering in the issue comment.
+ */
+const VERIFY_REPORT_FILE = path.join(OUTPUT_DIR, 'verify_report.md')
+const SCREENSHOTS_DIR = `.agent/verify/issue-${ISSUE_NUMBER}`
+
 const result = await sandcastle.run({
   name: `implement-#${ISSUE_NUMBER}`,
   agent: sandcastle.claudeCode('claude-opus-4-8', {
@@ -49,7 +59,9 @@ const result = await sandcastle.run({
     ISSUE_TITLE,
     BRANCH,
     PR_DESCRIPTION_FILE,
-    STANDARDS_DIR
+    STANDARDS_DIR,
+    VERIFY_REPORT_FILE,
+    SCREENSHOTS_DIR
   },
   // Runaway guard. Sandcastle's claudeCode does not expose Claude's `--max-turns`
   // flag, so the hard caps are wall-clock: this idle timeout (no output for N

--- a/.sandcastle/implement/post-verify.ts
+++ b/.sandcastle/implement/post-verify.ts
@@ -1,0 +1,101 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { execFileSync } from 'node:child_process'
+import { buildVerifyComment } from './verify-comment'
+
+/**
+ * IO entry point for the verify phase's "post proof to the issue" step (#523).
+ * Runs *after* the branch is pushed (so raw URLs resolve): reads the agent's
+ * verify report, enumerates the committed screenshots under
+ * `.agent/verify/issue-<N>/`, builds the comment via the pure
+ * `buildVerifyComment` helper, and posts it with `gh issue comment`.
+ *
+ * Best-effort by contract: verify never blocks the PR, so any failure here is
+ * logged and swallowed (exit 0) rather than failing the run.
+ */
+
+const ISSUE_NUMBER = required('ISSUE_NUMBER')
+const REPO = required('GITHUB_REPOSITORY')
+const BRANCH = required('BRANCH')
+const RUN_URL = process.env.RUN_URL ?? ''
+
+const OUTPUT_DIR = process.env.OUTPUT_DIR ?? os.tmpdir()
+const VERIFY_REPORT_FILE =
+  process.env.VERIFY_REPORT_FILE ?? path.join(OUTPUT_DIR, 'verify_report.md')
+
+/** Repo-relative dir holding the committed PNGs (also where raw URLs point). */
+const SCREENSHOTS_DIR =
+  process.env.SCREENSHOTS_DIR ?? `.agent/verify/issue-${ISSUE_NUMBER}`
+
+try {
+  const report = readReport(VERIFY_REPORT_FILE)
+  const screenshots = listScreenshots(SCREENSHOTS_DIR)
+
+  const body = buildVerifyComment({
+    report,
+    repo: REPO,
+    branch: BRANCH,
+    screenshots,
+    runUrl: RUN_URL
+  })
+
+  const bodyFile = path.join(OUTPUT_DIR, 'verify_comment.md')
+  fs.writeFileSync(bodyFile, body)
+
+  gh([
+    'issue',
+    'comment',
+    ISSUE_NUMBER,
+    '--repo',
+    REPO,
+    '--body-file',
+    bodyFile
+  ])
+  console.log(
+    `Posted verify comment to #${ISSUE_NUMBER} (${screenshots.length} screenshot(s)).`
+  )
+} catch (error) {
+  // Never fail the run over the comment — implement commits already landed.
+  console.warn(`Could not post verify comment: ${String(error)}`)
+}
+
+/** Reads the agent's report, or a fallback note when it is missing/empty. */
+function readReport(file: string): string {
+  try {
+    const text = fs.readFileSync(file, 'utf8').trim()
+    if (text) return text
+  } catch {
+    // fall through to the fallback below
+  }
+  return `Verification did not produce a report for #${ISSUE_NUMBER} — verify manually.`
+}
+
+/**
+ * Repo-relative paths of the committed `*.png` screenshots, sorted for a stable
+ * order. Empty when the dir is absent (non-UI / skipped runs).
+ */
+function listScreenshots(dir: string): string[] {
+  try {
+    return fs
+      .readdirSync(dir)
+      .filter((name) => name.toLowerCase().endsWith('.png'))
+      .sort()
+      .map((name) => `${dir}/${name}`)
+  } catch {
+    return []
+  }
+}
+
+function gh(args: string[]) {
+  return execFileSync('gh', args, { encoding: 'utf8' })
+}
+
+function required(name: string) {
+  const value = process.env[name]
+  if (!value) {
+    console.error(`Missing required env var: ${name}`)
+    process.exit(1)
+  }
+  return value
+}

--- a/.sandcastle/implement/prompt.md
+++ b/.sandcastle/implement/prompt.md
@@ -82,6 +82,56 @@ Make one or more commits on `{{BRANCH}}` with conventional-commit messages
 (`feat:`, `fix:`, `refactor:`, `test:`, `docs:`, `chore:`). Keep commits
 focused. Do not amend or force-push; just add commits.
 
+# VERIFY — prove it works (best-effort, never blocks the PR)
+
+After your green-gate commits, prove the change actually works for a user. This
+runs on top of the project's Playwright e2e harness (`playwright.config.ts`, the
+`e2e/` directory, the shared auth fixture in `e2e/auth.setup.ts`, and the
+`bun run test:e2e` script). The database is already seeded with the user
+`alice@prisma.io` (one recipe), so login and populated-state assertions are
+deterministic — do **not** re-script login or app boot; reuse the fixture.
+
+**1. Judge UI-verifiability.** From the issue's acceptance criteria, decide
+whether the change is observable in the running app (a screen renders, an
+interaction works). Backend-only / infra / tooling changes are **not**
+UI-verifiable.
+
+**2a. If it IS UI-verifiable** — write a durable spec, run it, capture proof:
+
+- Add or extend a spec under `e2e/` (e.g. `e2e/<feature>.spec.ts`) that drives
+  the issue's user flow through the real app and asserts on what the user sees
+  (never on internal state). This is a real regression test that stays in the
+  repo — part of your TDD, not a throwaway script. It reuses the authenticated
+  `storageState` from the `chromium` project, so it starts already logged in.
+- In the spec, capture a screenshot of the final working state of each
+  user-facing acceptance criterion (and a failure-state shot if you hit one)
+  with `await page.screenshot({ path: '{{SCREENSHOTS_DIR}}/<criterion>.png' })`.
+  Use the exact directory `{{SCREENSHOTS_DIR}}` — the workflow reads PNGs there.
+- Re-seed the database with `bun run seed` immediately before running the
+  browser (your integration tests during the gate truncate the tables, so the
+  seeded user must be restored), then run `bun run test:e2e` (Playwright boots
+  the built app via its `webServer` against the seeded DB). Fix the spec until
+  it passes.
+- **Commit** the new/updated `e2e/` spec **and** the PNGs under
+  `{{SCREENSHOTS_DIR}}` onto `{{BRANCH}}` (the screenshots are committed on
+  purpose so they get raw URLs and render inline on the issue).
+
+**2b. If it is NOT UI-verifiable** — skip the browser work entirely. Write no
+spec and no screenshots. Say so in the report (verified via the unit/integration
+suite, not the UI).
+
+**3. Never let verify fail the run.** Verify is best-effort. If the app won't
+boot or `test:e2e` errors, do not fail — capture whatever evidence you can
+(including a failure-state screenshot / the Playwright trace), and explain the
+problem in the report. Your green implement commits stand regardless.
+
+**4. Write the verify report.** Write a short markdown report to the absolute
+path `{{VERIFY_REPORT_FILE}}`. **Do not commit this file** — it lives outside the
+repo and the workflow posts it as a comment on the issue. Cover: whether the
+change was UI-verifiable, what user flow you checked (tie each screenshot to an
+acceptance criterion), the verdict (verified / couldn't verify and why), and the
+name of the e2e spec you added. If you captured no screenshots, say why.
+
 # FINAL STEP — write the PR description
 
 As the very last thing, write a short PR description (plain markdown) to the

--- a/.sandcastle/implement/verify-comment.test.ts
+++ b/.sandcastle/implement/verify-comment.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment node
+ */
+import { buildVerifyComment, rawUrl } from './verify-comment'
+
+describe('rawUrl', () => {
+  it('builds a raw.githubusercontent.com URL preserving path slashes', () => {
+    expect(
+      rawUrl('galosandoval/recipe-chat', 'main', '.agent/verify/issue-5/a.png')
+    ).toBe(
+      'https://raw.githubusercontent.com/galosandoval/recipe-chat/main/.agent/verify/issue-5/a.png'
+    )
+  })
+
+  it('percent-encodes segments but keeps slashes (agent branch names)', () => {
+    expect(
+      rawUrl(
+        'galosandoval/recipe-chat',
+        'agent/issue-5-add thing',
+        '.agent/verify/issue-5/final state.png'
+      )
+    ).toBe(
+      'https://raw.githubusercontent.com/galosandoval/recipe-chat/agent/issue-5-add%20thing/.agent/verify/issue-5/final%20state.png'
+    )
+  })
+})
+
+describe('buildVerifyComment', () => {
+  const base = {
+    report: 'Verified the recipes flow.',
+    repo: 'galosandoval/recipe-chat',
+    branch: 'agent/issue-5',
+    runUrl: 'https://github.com/galosandoval/recipe-chat/actions/runs/1'
+  }
+
+  it('renders each screenshot inline with a raw URL', () => {
+    const body = buildVerifyComment({
+      ...base,
+      screenshots: ['.agent/verify/issue-5/recipes.png']
+    })
+    expect(body).toContain('Verified the recipes flow.')
+    expect(body).toContain(
+      '![recipes.png](https://raw.githubusercontent.com/galosandoval/recipe-chat/agent/issue-5/.agent/verify/issue-5/recipes.png)'
+    )
+    expect(body).toContain('### Screenshots')
+    expect(body).toContain('[View the workflow run](')
+  })
+
+  it('omits the screenshots section when there are none (non-UI / skipped)', () => {
+    const body = buildVerifyComment({ ...base, screenshots: [] })
+    expect(body).toContain('Verified the recipes flow.')
+    expect(body).not.toContain('### Screenshots')
+    expect(body).toContain('[View the workflow run](')
+  })
+
+  it('falls back to a placeholder when the report is empty', () => {
+    const body = buildVerifyComment({ ...base, report: '   ', screenshots: [] })
+    expect(body).toContain('_No verify report was produced._')
+  })
+})

--- a/.sandcastle/implement/verify-comment.test.ts
+++ b/.sandcastle/implement/verify-comment.test.ts
@@ -1,29 +1,7 @@
 /**
  * @jest-environment node
  */
-import { buildVerifyComment, rawUrl } from './verify-comment'
-
-describe('rawUrl', () => {
-  it('builds a raw.githubusercontent.com URL preserving path slashes', () => {
-    expect(
-      rawUrl('galosandoval/recipe-chat', 'main', '.agent/verify/issue-5/a.png')
-    ).toBe(
-      'https://raw.githubusercontent.com/galosandoval/recipe-chat/main/.agent/verify/issue-5/a.png'
-    )
-  })
-
-  it('percent-encodes segments but keeps slashes (agent branch names)', () => {
-    expect(
-      rawUrl(
-        'galosandoval/recipe-chat',
-        'agent/issue-5-add thing',
-        '.agent/verify/issue-5/final state.png'
-      )
-    ).toBe(
-      'https://raw.githubusercontent.com/galosandoval/recipe-chat/agent/issue-5-add%20thing/.agent/verify/issue-5/final%20state.png'
-    )
-  })
-})
+import { buildVerifyComment } from './verify-comment'
 
 describe('buildVerifyComment', () => {
   const base = {
@@ -44,6 +22,17 @@ describe('buildVerifyComment', () => {
     )
     expect(body).toContain('### Screenshots')
     expect(body).toContain('[View the workflow run](')
+  })
+
+  it('percent-encodes branch and filename segments but keeps slashes', () => {
+    const body = buildVerifyComment({
+      ...base,
+      branch: 'agent/issue-5-add thing',
+      screenshots: ['.agent/verify/issue-5/final state.png']
+    })
+    expect(body).toContain(
+      '![final state.png](https://raw.githubusercontent.com/galosandoval/recipe-chat/agent/issue-5-add%20thing/.agent/verify/issue-5/final%20state.png)'
+    )
   })
 
   it('omits the screenshots section when there are none (non-UI / skipped)', () => {

--- a/.sandcastle/implement/verify-comment.ts
+++ b/.sandcastle/implement/verify-comment.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure helpers for the agent verify phase (#523): turn a committed-screenshots
+ * list + branch + repo into the markdown issue comment the workflow posts. No
+ * `gh`, filesystem, or Playwright calls live here — that I/O is in
+ * `post-verify.ts`, exactly as `run-preflight.ts` wraps the pure `preflight.ts`.
+ */
+
+export interface VerifyCommentInput {
+  /** The agent's verify report (markdown), or a fallback note when absent. */
+  report: string
+  /** `owner/repo`, e.g. `galosandoval/recipe-chat`. */
+  repo: string
+  /** Branch the screenshots were committed to (raw URLs resolve against it). */
+  branch: string
+  /**
+   * Repo-relative paths of the committed screenshots, e.g.
+   * `.agent/verify/issue-5/recipes.png`. Empty for non-UI / skipped runs.
+   */
+  screenshots: string[]
+  /** URL of the workflow run, linked so the issue jumps to the full logs. */
+  runUrl: string
+}
+
+/**
+ * Builds a `raw.githubusercontent.com` URL for a committed file so the image
+ * renders inline in the issue comment. Each path/branch segment is
+ * percent-encoded while the slashes are preserved.
+ */
+export function rawUrl(repo: string, branch: string, filePath: string): string {
+  const encode = (segmented: string) =>
+    segmented.split('/').map(encodeURIComponent).join('/')
+  return `https://raw.githubusercontent.com/${repo}/${encode(branch)}/${encode(filePath)}`
+}
+
+/**
+ * Assembles the full issue-comment body: the agent's verify report, an inline
+ * image for each committed screenshot (raw URLs against `branch`), and a link
+ * to the workflow run. With no screenshots (non-UI / skipped / failed-capture
+ * runs) the report and run link stand alone.
+ */
+export function buildVerifyComment(input: VerifyCommentInput): string {
+  const { report, repo, branch, screenshots, runUrl } = input
+
+  const parts = [report.trim() || '_No verify report was produced._']
+
+  if (screenshots.length > 0) {
+    const images = screenshots.map((file) => {
+      const name = file.split('/').pop() ?? file
+      return `![${name}](${rawUrl(repo, branch, file)})`
+    })
+    parts.push(`### Screenshots\n\n${images.join('\n\n')}`)
+  }
+
+  parts.push(`[View the workflow run](${runUrl})`)
+
+  return `${parts.join('\n\n')}\n`
+}

--- a/.sandcastle/implement/verify-comment.ts
+++ b/.sandcastle/implement/verify-comment.ts
@@ -26,7 +26,7 @@ export interface VerifyCommentInput {
  * renders inline in the issue comment. Each path/branch segment is
  * percent-encoded while the slashes are preserved.
  */
-export function rawUrl(repo: string, branch: string, filePath: string): string {
+function rawUrl(repo: string, branch: string, filePath: string): string {
   const encode = (segmented: string) =>
     segmented.split('/').map(encodeURIComponent).join('/')
   return `https://raw.githubusercontent.com/${repo}/${encode(branch)}/${encode(filePath)}`

--- a/bun.lock
+++ b/bun.lock
@@ -57,6 +57,7 @@
       "devDependencies": {
         "@ai-hero/sandcastle": "0.10.0",
         "@hookform/resolvers": "^3.10.0",
+        "@playwright/test": "^1.49.1",
         "@tailwindcss/typography": "^0.5.16",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.8.0",
@@ -75,8 +76,10 @@
         "eslint": "8.28.0",
         "eslint-config-next": "^13.4.6",
         "eslint-plugin-react-compiler": "^19.1.0-rc.2",
+        "husky": "^9.1.7",
         "jest": "^30.1.2",
         "jest-environment-jsdom": "^30.1.2",
+        "lint-staged": "^15.2.10",
         "prettier": "^3.0.3",
         "prettier-plugin-tailwindcss": "^0.6.14",
         "prisma": "^6.18.0",
@@ -384,6 +387,8 @@
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
+
+    "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
 
     "@prisma/client": ["@prisma/client@6.18.0", "", { "peerDependencies": { "prisma": "*", "typescript": ">=5.1.0" } }, "sha512-jnL2I9gDnPnw4A+4h5SuNn8Gc+1mL1Z79U/3I9eE2gbxJG1oSA+62ByPW4xkeDgwE0fqMzzpAZ7IHxYnLZ4iQA=="],
 
@@ -785,6 +790,10 @@
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
+    "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+
+    "cli-truncate": ["cli-truncate@4.0.0", "", { "dependencies": { "slice-ansi": "^5.0.0", "string-width": "^7.0.0" } }, "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA=="],
+
     "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
@@ -803,7 +812,11 @@
 
     "color-string": ["color-string@1.9.1", "", { "dependencies": { "color-name": "^1.0.0", "simple-swizzle": "^0.2.2" } }, "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg=="],
 
+    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
@@ -915,6 +928,8 @@
 
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
+    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+
     "error-ex": ["error-ex@1.3.2", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g=="],
 
     "es-abstract": ["es-abstract@1.24.0", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.3.0", "get-proto": "^1.0.1", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-negative-zero": "^2.0.3", "is-regex": "^1.2.1", "is-set": "^2.0.3", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.1", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.4", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.4", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "stop-iteration-iterator": "^1.1.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.19" } }, "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg=="],
@@ -977,7 +992,9 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
-    "execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "execa": ["execa@8.0.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^8.0.1", "human-signals": "^5.0.0", "is-stream": "^3.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^5.1.0", "onetime": "^6.0.0", "signal-exit": "^4.1.0", "strip-final-newline": "^3.0.0" } }, "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg=="],
 
     "exit-x": ["exit-x@0.2.2", "", {}, "sha512-+I6B/IkJc1o/2tiURyz/ivu/O0nKNEArIUB5O7zBrlDVJr22SCLH3xTeEry428LvFhRzIA1g8izguxJ/gbNcVQ=="],
 
@@ -1029,7 +1046,7 @@
 
     "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -1043,6 +1060,8 @@
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
+
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
@@ -1051,7 +1070,7 @@
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
-    "get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
+    "get-stream": ["get-stream@8.0.1", "", {}, "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA=="],
 
     "get-symbol-description": ["get-symbol-description@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6" } }, "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg=="],
 
@@ -1105,7 +1124,9 @@
 
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
-    "human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
+    "human-signals": ["human-signals@5.0.0", "", {}, "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ=="],
+
+    "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
@@ -1175,7 +1196,7 @@
 
     "is-shared-array-buffer": ["is-shared-array-buffer@1.0.4", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A=="],
 
-    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+    "is-stream": ["is-stream@3.0.0", "", {}, "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA=="],
 
     "is-string": ["is-string@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA=="],
 
@@ -1323,7 +1344,13 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.30.1", "", { "os": "win32", "cpu": "x64" }, "sha512-PVqXh48wh4T53F/1CCu8PIPCxLzWyCnn/9T5W1Jpmdy5h9Cwd+0YQS6/LwhHXSafuc61/xg9Lv5OrCby6a++jg=="],
 
+    "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
+
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "lint-staged": ["lint-staged@15.5.2", "", { "dependencies": { "chalk": "^5.4.1", "commander": "^13.1.0", "debug": "^4.4.0", "execa": "^8.0.1", "lilconfig": "^3.1.3", "listr2": "^8.2.5", "micromatch": "^4.0.8", "pidtree": "^0.6.0", "string-argv": "^0.3.2", "yaml": "^2.7.0" }, "bin": { "lint-staged": "bin/lint-staged.js" } }, "sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w=="],
+
+    "listr2": ["listr2@8.3.3", "", { "dependencies": { "cli-truncate": "^4.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
@@ -1332,6 +1359,8 @@
     "lodash.isplainobject": ["lodash.isplainobject@4.0.6", "", {}, "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="],
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": "cli.js" }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
@@ -1361,7 +1390,9 @@
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
-    "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
+    "mimic-fn": ["mimic-fn@4.0.0", "", {}, "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw=="],
+
+    "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
 
     "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
@@ -1411,7 +1442,7 @@
 
     "nosleep.js": ["nosleep.js@0.12.0", "", {}, "sha512-9d1HbpKLh3sdWlhXMhU6MMH+wQzKkrgfRkYV0EBdvt99YJfj0ilCJrWRDYG2130Tm4GXbEoTCx5b34JSaP+HhA=="],
 
-    "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
+    "npm-run-path": ["npm-run-path@5.3.0", "", { "dependencies": { "path-key": "^4.0.0" } }, "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ=="],
 
     "nth-check": ["nth-check@2.1.1", "", { "dependencies": { "boolbase": "^1.0.0" } }, "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w=="],
 
@@ -1441,7 +1472,7 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
-    "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
+    "onetime": ["onetime@6.0.0", "", { "dependencies": { "mimic-fn": "^4.0.0" } }, "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ=="],
 
     "openai-edge": ["openai-edge@1.2.2", "", {}, "sha512-C3/Ao9Hkx5uBPv9YFBpX/x59XMPgPUU4dyGg/0J2sOJ7O9D98kD+lfdOc7v/60oYo5xzMGct80uFkYLH+X2qgw=="],
 
@@ -1485,13 +1516,19 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+    "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "pidtree": ["pidtree@0.6.1", "", { "bin": { "pidtree": "bin/pidtree.js" } }, "sha512-e0F9AOF1JMrCfBsyJOwU9lNvQ0WtXTq0j/4jk0BQ5JSI9VAybPXmDpPRw/2FQ3e5d3ZFN1mLh7jW99m/jjaptw=="],
 
     "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
 
     "pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
 
     "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
+
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
+
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
@@ -1569,7 +1606,11 @@
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
+    "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
     "rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": "bin.js" }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
 
@@ -1621,6 +1662,8 @@
 
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
 
+    "slice-ansi": ["slice-ansi@5.0.0", "", { "dependencies": { "ansi-styles": "^6.0.0", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ=="],
+
     "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
@@ -1638,6 +1681,8 @@
     "stop-iteration-iterator": ["stop-iteration-iterator@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "internal-slot": "^1.1.0" } }, "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ=="],
 
     "streamsearch": ["streamsearch@1.1.0", "", {}, "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="],
+
+    "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
 
     "string-length": ["string-length@4.0.2", "", { "dependencies": { "char-regex": "^1.0.2", "strip-ansi": "^6.0.0" } }, "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ=="],
 
@@ -1663,7 +1708,7 @@
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
-    "strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
+    "strip-final-newline": ["strip-final-newline@3.0.0", "", {}, "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="],
 
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
 
@@ -1795,7 +1840,7 @@
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
-    "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -1812,6 +1857,8 @@
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
@@ -1879,11 +1926,13 @@
 
     "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
-    "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
-
     "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "cheerio/undici": ["undici@7.11.0", "", {}, "sha512-heTSIac3iLhsmZhUCjyS3JQEkZELateufzZuBaVM5RHXdSBMb1LPMQf5x+FH7qjsZYDP0ttAc3nnVpUB+wYbOg=="],
+
+    "cli-truncate/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
@@ -1905,15 +1954,17 @@
 
     "eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@2.1.0", "", {}, "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="],
 
-    "execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
-
     "fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "fdir/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
     "htmlparser2/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "istanbul-lib-source-maps/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.29", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ=="],
+
+    "jest-changed-files/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
 
     "jest-circus/pretty-format": ["pretty-format@30.0.5", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw=="],
 
@@ -1924,6 +1975,8 @@
     "jest-diff/pretty-format": ["pretty-format@30.0.5", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw=="],
 
     "jest-each/pretty-format": ["pretty-format@30.0.5", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw=="],
+
+    "jest-haste-map/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "jest-leak-detector/pretty-format": ["pretty-format@30.0.5", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw=="],
 
@@ -1937,17 +1990,27 @@
 
     "jest-snapshot/pretty-format": ["pretty-format@30.0.5", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw=="],
 
+    "jest-util/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
     "jest-validate/pretty-format": ["pretty-format@30.0.5", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw=="],
 
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
 
     "jsondiffpatch/chalk": ["chalk@5.4.1", "", {}, "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w=="],
 
+    "lint-staged/chalk": ["chalk@5.4.1", "", {}, "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w=="],
+
+    "log-update/ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
+
+    "log-update/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
+
+    "log-update/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+
     "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
-    "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
-
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+
+    "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
@@ -1959,7 +2022,13 @@
 
     "resolve-cwd/resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
+    "restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
     "simple-swizzle/is-arrayish": ["is-arrayish@0.3.2", "", {}, "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="],
+
+    "slice-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
+    "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@4.0.0", "", {}, "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="],
 
     "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
 
@@ -1975,7 +2044,11 @@
 
     "v8-to-istanbul/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.29", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ=="],
 
-    "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
+    "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "wrap-ansi/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
 
     "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
@@ -2009,6 +2082,26 @@
 
     "@vercel/blob/jest-environment-jsdom/jsdom": ["jsdom@20.0.3", "", { "dependencies": { "abab": "^2.0.6", "acorn": "^8.8.1", "acorn-globals": "^7.0.0", "cssom": "^0.5.0", "cssstyle": "^2.3.0", "data-urls": "^3.0.2", "decimal.js": "^10.4.2", "domexception": "^4.0.0", "escodegen": "^2.0.0", "form-data": "^4.0.0", "html-encoding-sniffer": "^3.0.0", "http-proxy-agent": "^5.0.0", "https-proxy-agent": "^5.0.1", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.2", "parse5": "^7.1.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^4.1.2", "w3c-xmlserializer": "^4.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^2.0.0", "whatwg-mimetype": "^3.0.0", "whatwg-url": "^11.0.0", "ws": "^8.11.0", "xml-name-validator": "^4.0.0" }, "peerDependencies": { "canvas": "^2.5.0" }, "optionalPeers": ["canvas"] }, "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ=="],
 
+    "cli-truncate/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "cli-truncate/string-width/strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+
+    "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "jest-changed-files/execa/get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
+
+    "jest-changed-files/execa/human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
+
+    "jest-changed-files/execa/is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
+    "jest-changed-files/execa/npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
+
+    "jest-changed-files/execa/onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
+
+    "jest-changed-files/execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "jest-changed-files/execa/strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
+
     "jest-circus/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
     "jest-config/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
@@ -2031,7 +2124,17 @@
 
     "jest-validate/pretty-format/react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
+    "log-update/slice-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
+    "log-update/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
+    "log-update/strip-ansi/ansi-regex": ["ansi-regex@6.2.0", "", {}, "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg=="],
+
     "pkg-dir/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+
+    "wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.0", "", {}, "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg=="],
 
     "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 
@@ -2044,8 +2147,6 @@
     "@vercel/blob/jest-environment-jsdom/@jest/types/@jest/schemas": ["@jest/schemas@29.6.3", "", { "dependencies": { "@sinclair/typebox": "^0.27.8" } }, "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA=="],
 
     "@vercel/blob/jest-environment-jsdom/jest-util/ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
-
-    "@vercel/blob/jest-environment-jsdom/jest-util/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "@vercel/blob/jest-environment-jsdom/jsdom/cssstyle": ["cssstyle@2.3.0", "", { "dependencies": { "cssom": "~0.3.6" } }, "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A=="],
 
@@ -2068,6 +2169,10 @@
     "@vercel/blob/jest-environment-jsdom/jsdom/whatwg-url": ["whatwg-url@11.0.0", "", { "dependencies": { "tr46": "^3.0.0", "webidl-conversions": "^7.0.0" } }, "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ=="],
 
     "@vercel/blob/jest-environment-jsdom/jsdom/xml-name-validator": ["xml-name-validator@4.0.0", "", {}, "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw=="],
+
+    "cli-truncate/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.0", "", {}, "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg=="],
+
+    "jest-changed-files/execa/onetime/mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
     "jest-config/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 

--- a/docs/agents/agent-pipeline-setup.md
+++ b/docs/agents/agent-pipeline-setup.md
@@ -23,6 +23,62 @@ The pipeline state machine uses these labels (created in this slice):
 
 `ready-for-agent` (pre-existing) stays as the upstream human-triage state and costs nothing.
 
+## End-to-end harness + verify phase (#523)
+
+The pipeline gains a **Playwright e2e harness** and the agent's **verify phase**.
+
+### Playwright harness
+
+- `playwright.config.ts` (repo root) boots the built app via its `webServer`
+  block (`bun run build && bun run start`), points `baseURL` at it, and captures
+  screenshots/trace/video as proof.
+- Specs live in a top-level **`e2e/`** directory. This is a deliberate,
+  documented exception to the repo's "tests are colocated, no `__tests__/`"
+  convention — e2e specs span features and don't belong beside a single prod
+  file. Unit/integration tests stay colocated.
+- `e2e/auth.setup.ts` logs in once as the seeded user (`alice@prisma.io`) and
+  saves a `storageState` every spec reuses, so no spec re-scripts login/boot.
+- Run locally with `bun run test:e2e` (or `bun run test:e2e:ui`). It is **not**
+  part of the default `bun run test` gate, so the unit/integration gate and the
+  agent's per-commit loop stay fast and never boot a browser. Jest is configured
+  to ignore `e2e/` (its specs also match `*.spec.ts`).
+- The seeded user's password is bcrypt-hashed in `prisma/seed.ts` (and the user
+  gets an empty `list`), so the seeded login works through the real Credentials
+  provider. Both the agent verify phase and the PR `e2e` job seed the DB before
+  the browser run (`bun run seed`).
+
+### Agent verify phase
+
+Appended to the existing `implement` job (no new job/workflow/label/secret).
+After the green-gate commits and before the draft PR:
+
+1. The agent (see `prompt.md`'s VERIFY section) judges UI-verifiability from the
+   acceptance criteria.
+2. If UI-verifiable: writes a durable `e2e/` spec, re-seeds, runs
+   `bun run test:e2e`, captures screenshots into `.agent/verify/issue-<N>/`, and
+   commits the spec + PNGs. The PNGs are committed on purpose so they get raw
+   URLs and render inline on the issue.
+3. Writes a verify report to `OUTPUT_DIR/verify_report.md` (outside the repo,
+   like `pr_description.txt`).
+
+The workflow then pushes the branch and runs `post-verify.ts`, which builds one
+issue comment (report + inline screenshots + run link via the pure
+`verify-comment.ts` helper) and posts it with `gh issue comment`. Verify is
+**best-effort**: a failed boot/browser run never fails the run or loses the green
+implement commits; the comment says verification couldn't complete and why.
+
+> **Trade-off:** committed PNGs under `.agent/verify/issue-<N>/` merge into
+> `main` unless stripped before merge — clearly named and outside the app bundle
+> so they're trivial to drop in a squash. The `e2e/` spec is meant to stay.
+
+### PR e2e gate
+
+`.github/workflows/test.yml` adds a `changes` job (dorny/paths-filter) and an
+`e2e` job that runs **only when backend code changed** (`src/server/**`,
+`prisma/**`, `e2e/**`, `playwright.config.*`). Docs/config/pure-styling PRs skip
+it. The `e2e` job needs `NEXTAUTH_SECRET` + `OPENAI_API_KEY` (already required
+secrets) to boot the app; a real misconfig fails it loudly.
+
 ## Required repo secrets
 
 Set these under **Settings → Secrets and variables → Actions → Repository secrets**.

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,0 +1,34 @@
+import { test as setup, expect } from '@playwright/test'
+import { STORAGE_STATE } from '../playwright.config'
+
+/**
+ * Seeded credentials. Must match `prisma/seed.ts` (`SEED_USER`) — the DB is
+ * seeded with this user (bcrypt-hashed password) before the e2e run, so logging
+ * in here exercises the real Credentials provider.
+ */
+const SEED_USER = {
+  email: 'alice@prisma.io',
+  password: 'Admin@123'
+}
+
+/**
+ * Logs in once through the real UI and saves the authenticated session to
+ * `STORAGE_STATE`. Every spec in the `chromium` project reuses that state via
+ * its `storageState` setting, so no spec re-scripts login or boot.
+ */
+setup('authenticate', async ({ page }) => {
+  await page.goto('/')
+
+  // Open the login drawer/dialog from the landing page, then submit the form.
+  await page.getByRole('button', { name: 'Login' }).first().click()
+  const dialog = page.getByRole('dialog')
+  await dialog.getByLabel('Email').fill(SEED_USER.email)
+  await dialog.getByLabel('Password').fill(SEED_USER.password)
+  await dialog.getByRole('button', { name: 'Login' }).click()
+
+  // A successful credentials sign-in redirects to /chat.
+  await page.waitForURL('**/chat')
+  await expect(page).toHaveURL(/\/chat/)
+
+  await page.context().storageState({ path: STORAGE_STATE })
+})

--- a/e2e/recipes.spec.ts
+++ b/e2e/recipes.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * Smoke spec proving the harness end to end: an authenticated session (from the
+ * `setup` project) can load the recipes page and see the seeded recipe. This is
+ * the first durable e2e spec; the agent's verify phase adds issue-specific specs
+ * alongside it.
+ */
+test('authenticated user sees their seeded recipe on /recipes', async ({
+  page
+}) => {
+  await page.goto('/recipes')
+
+  // The seeded user (alice@prisma.io) has one recipe; its name renders as a
+  // heading on the recipes grid.
+  await expect(
+    page.getByText('CREAMY MUSHROOM TOAST', { exact: false })
+  ).toBeVisible()
+})

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -17,6 +17,9 @@ const config: Config = {
   },
   // Ignore nested worktree copies so Haste doesn't see duplicate package.json.
   modulePathIgnorePatterns: ['<rootDir>/.claude/worktrees/'],
+  // Playwright specs under e2e/ also match *.spec.ts; they are run by Playwright
+  // (`bun run test:e2e`), never Jest. Keep them out of the unit/integration gate.
+  testPathIgnorePatterns: ['/node_modules/', '<rootDir>/e2e/'],
   // Only treat *.test/*.spec files as suites, so test helpers can live in
   // __tests__ dirs without being mistaken for empty test files.
   testMatch: ['**/?(*.)+(spec|test).[jt]s?(x)'],

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "next dev",
     "studio": "bunx prisma studio",
     "studio:prod": "dotenv -e .env.production --  bunx prisma studio",
+    "prepare": "husky",
     "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
@@ -22,9 +23,11 @@
     "gen": "bunx prisma generate",
     "migrate-reset": "bunx prisma migrate reset",
     "test": "bunx jest",
-    "test:unit": "bunx jest --testPathIgnorePatterns node_modules src/server/api",
+    "test:unit": "bunx jest --testPathIgnorePatterns node_modules src/server/api e2e",
     "test:integration": "bunx jest src/server/api",
     "test:watch": "bunx jest --watch",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "test:db:setup": "dotenv -e .env.test.local -- prisma migrate deploy",
     "data-migration:add-saved-column": "tsx ./prisma/migrations/20250730012052_add_saved_column/data-migration.ts",
     "data-migration:create-many-recipes-to-many-messages-table": "tsx ./prisma/migrations/20250730020516_create_many_recipes_to_many_messages_table/data-migration.ts",
@@ -34,6 +37,12 @@
     "data-migration:backfill-recipe-embeddings": "bunx tsx ./prisma/migrations/20260623000000_backfill_recipe_embeddings/data-migration.ts",
     "data-migration:run:prod": "dotenv -e .env.production -- bun prisma/run-data-migrations.ts",
     "stripe:listen": "stripe listen --forward-to localhost:3000/api/webhooks/stripe"
+  },
+  "prisma": {
+    "seed": "bun prisma/seed.ts"
+  },
+  "lint-staged": {
+    "*": "prettier --write --ignore-unknown"
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.3.23",
@@ -89,6 +98,7 @@
   "devDependencies": {
     "@ai-hero/sandcastle": "0.10.0",
     "@hookform/resolvers": "^3.10.0",
+    "@playwright/test": "^1.49.1",
     "@tailwindcss/typography": "^0.5.16",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.8.0",
@@ -107,8 +117,10 @@
     "eslint": "8.28.0",
     "eslint-config-next": "^13.4.6",
     "eslint-plugin-react-compiler": "^19.1.0-rc.2",
+    "husky": "^9.1.7",
     "jest": "^30.1.2",
     "jest-environment-jsdom": "^30.1.2",
+    "lint-staged": "^15.2.10",
     "prettier": "^3.0.3",
     "prettier-plugin-tailwindcss": "^0.6.14",
     "prisma": "^6.18.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,69 @@
+import { defineConfig, devices } from '@playwright/test'
+import * as path from 'node:path'
+
+/**
+ * Playwright e2e harness (#523). This is the project's end-to-end test runner —
+ * a deliberate, documented exception to the repo's "tests are colocated, no
+ * `__tests__/`" convention: e2e specs span features and live under `e2e/`.
+ *
+ * Run with `bun run test:e2e`. The suite is intentionally NOT part of the
+ * default `bun run test` gate, so the unit/integration gate (and the agent's
+ * per-commit loop) stays fast and never boots a browser. e2e runs only (a) in
+ * the agent's verify phase and (b) the path-filtered `e2e` CI job.
+ *
+ * The `webServer` block builds and boots the real app, so a local/CI run is one
+ * command. Specs authenticate once via the `setup` project (see
+ * `e2e/auth.setup.ts`), which writes a `storageState` reused by every spec.
+ */
+
+/** Where the authenticated session (cookies) is cached between specs. */
+export const STORAGE_STATE = path.join(
+  __dirname,
+  'e2e/.auth/storage-state.json'
+)
+
+const PORT = Number(process.env.PORT ?? 3000)
+const BASE_URL = process.env.E2E_BASE_URL ?? `http://localhost:${PORT}`
+
+export default defineConfig({
+  testDir: './e2e',
+  // Build/boot/browser is slow; give specs room but keep a hard ceiling.
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  // Never `.only` past CI; let flakes retry there but fail fast locally.
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+
+  use: {
+    baseURL: BASE_URL,
+    // Proof is a built-in: capture a screenshot for every test, a trace on the
+    // first retry, and video only when a test fails. Agent specs additionally
+    // take explicit `page.screenshot()` shots into `.agent/verify/issue-<N>/`.
+    screenshot: 'on',
+    trace: 'on-first-retry',
+    video: 'retain-on-failure'
+  },
+
+  projects: [
+    // Logs in once as the seeded user and saves the session to STORAGE_STATE.
+    { name: 'setup', testMatch: /auth\.setup\.ts/ },
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], storageState: STORAGE_STATE },
+      dependencies: ['setup']
+    }
+  ],
+
+  // Builds + boots the real app and waits for it to be reachable. Reuses an
+  // already-running dev/prod server locally; always starts fresh in CI.
+  webServer: {
+    command: 'bun run build && bun run start',
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    // First run pays for `next build`; allow generous startup time.
+    timeout: 180_000,
+    stdout: 'pipe',
+    stderr: 'pipe'
+  }
+})

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,17 +1,39 @@
 import { PrismaClient } from '@prisma/client'
+import { hash } from 'bcryptjs'
 import { slugify } from '~/lib/utils'
 
 const prisma = new PrismaClient()
 
+/**
+ * Seed credentials. The plaintext password is what the e2e auth fixture and a
+ * human typing into the login form use; it is bcrypt-hashed below so the
+ * Credentials provider's `compare()` succeeds (the login flow never sees
+ * plaintext in the DB). Not exported — this module runs `main()` as an import
+ * side effect, so it can't be safely imported; `e2e/auth.setup.ts` keeps its
+ * own copy of these values in sync.
+ */
+const SEED_USER = {
+  email: 'alice@prisma.io',
+  password: 'Admin@123'
+}
+
 async function main() {
+  // Hash like real signup (`createUser` uses `hash(password, 10)`) so the
+  // seeded user can authenticate through the Credentials provider; a plaintext
+  // password would fail `compare()` and make the seeded login unusable.
+  const hashedPassword = await hash(SEED_USER.password, 10)
+
   const alice = await prisma.user.upsert({
     where: { id: '1' },
     update: {},
     create: {
-      username: 'alice@prisma.io',
+      username: SEED_USER.email,
       firstName: 'Alice',
       lastName: 'Prisma',
-      password: 'Admin@123',
+      password: hashedPassword,
+      // Real signup creates an empty list; the session callback reads
+      // `user.list.id`, so the seeded user needs one too.
+      list: { create: {} },
 
       recipes: {
         create: {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -41,6 +41,10 @@ async function main() {
           author: 'gordon ramsay',
           address: 'https://www.gordonramsay.com/gr/recipes/mushroomtoast/',
           name: 'CREAMY MUSHROOM TOAST WITH SOFT EGG & GRUYÈRE',
+          // `getInfiniteRecipes` (the /recipes list) filters `saved: true`; the
+          // schema defaults `saved` to false, so the e2e recipes spec only sees
+          // this recipe when it's explicitly saved.
+          saved: true,
           description:
             'A twist on the beloved British favorite, delightfully simple and absolutely delicious for breakfast, brunch, lunch, or even dinner.',
 


### PR DESCRIPTION
…cation phase

- Updated .gitignore to include Playwright artifacts and test results.
- Added Playwright as a dev dependency in package.json.
- Configured Jest to ignore e2e tests and added Playwright test commands.
- Enhanced GitHub workflows to install Playwright and run e2e tests conditionally based on backend changes.
- Documented the new Playwright e2e harness and verification phase in agent-pipeline-setup.md.
- Updated prisma seed script to hash passwords for e2e testing.

This commit establishes a robust end-to-end testing framework, ensuring UI verifiability and improving the overall testing strategy.