### PR TITLE
Reunify the agent-implement run-policy contract (restore CI idle guard, derive --preserve-env, pin CLI)

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -67,7 +67,9 @@ jobs:
     # (wrong label/actor) leaves `refused` empty, so this stays skipped too.
     if: needs.preflight.outputs.refused == 'false'
     runs-on: ubuntu-latest
-    # Hard wall-clock cap on the whole run (runaway guard #1).
+    # Hard wall-clock cap on the whole run (runaway guard #1). The idle guard
+    # (#556) lives in the orchestrator (agent/implement/implement.ts) so it
+    # protects CI too, killing a hung run in minutes instead of at this cap.
     timeout-minutes: 45
 
     services:
@@ -146,13 +148,16 @@ jobs:
         run: bun install
 
       - name: Install Claude Code CLI
-        # bun's global installs skip lifecycle scripts (`--trust` only affects
-        # a project's package.json, not `-g`), so the postinstall that fetches
-        # the real platform-native binary must run explicitly — otherwise
-        # `claude` is left as a stub that fails to spawn (ENOEXEC). Same fix
-        # as agent/local/Dockerfile.
+        # Pinned to the version the run-policy contract declares (#556), read
+        # straight from the module so this step and agent/local/Dockerfile can
+        # never freeze at different CLI versions. bun's global installs skip
+        # lifecycle scripts (`--trust` only affects a project's package.json,
+        # not `-g`), so the postinstall that fetches the real platform-native
+        # binary must run explicitly — otherwise `claude` is left as a stub that
+        # fails to spawn (ENOEXEC).
         run: |
-          bun install -g @anthropic-ai/claude-code
+          version="$(bun agent/implement/run-policy.ts cli-version)"
+          bun install -g "@anthropic-ai/claude-code@${version}"
           bun_install_dir="$(dirname "$(bun pm -g bin)")"
           node "${bun_install_dir}/install/global/node_modules/@anthropic-ai/claude-code/install.cjs"
 

--- a/agent/implement/claude-invocation.test.ts
+++ b/agent/implement/claude-invocation.test.ts
@@ -5,6 +5,7 @@ import {
   prepareClaudeInvocation,
   type ClaudeInvocationInput
 } from './claude-invocation'
+import { MAX_TURNS, MODEL } from './run-policy'
 
 function baseInput(
   overrides: Partial<ClaudeInvocationInput> = {}
@@ -68,11 +69,20 @@ describe('prepareClaudeInvocation', () => {
       expect(args).toEqual([
         '--print',
         '--model',
-        'claude-opus-4-8',
+        MODEL,
         '--max-turns',
-        '150',
+        String(MAX_TURNS),
         '--dangerously-skip-permissions'
       ])
+    })
+
+    it('sources the model and max-turns flags from the run-policy contract', () => {
+      const { args } = prepareClaudeInvocation(baseInput())
+      const modelValue = args[args.indexOf('--model') + 1]
+      const maxTurnsValue = args[args.indexOf('--max-turns') + 1]
+
+      expect(modelValue).toBe(MODEL)
+      expect(maxTurnsValue).toBe(String(MAX_TURNS))
     })
 
     it('leaves the arg vector unchanged when streamOutput is omitted', () => {
@@ -89,9 +99,9 @@ describe('prepareClaudeInvocation', () => {
       expect(args).toEqual([
         '--print',
         '--model',
-        'claude-opus-4-8',
+        MODEL,
         '--max-turns',
-        '150',
+        String(MAX_TURNS),
         '--dangerously-skip-permissions',
         '--output-format',
         'stream-json',

--- a/agent/implement/claude-invocation.ts
+++ b/agent/implement/claude-invocation.ts
@@ -6,6 +6,8 @@
  * this module only computes what to spawn with.
  */
 
+import { MAX_TURNS, MODEL } from './run-policy'
+
 export interface ClaudeInvocationInput {
   /** Raw contents of `prompt.md`, with `{{PLACEHOLDER}}` tokens to render. */
   promptTemplate: string
@@ -35,11 +37,6 @@ export interface ClaudeInvocation {
   prompt: string
 }
 
-const CLAUDE_MODEL = 'claude-opus-4-8'
-/** Fast-loop backstop; layered on top of the idle timeout and (in CI) the
- *  workflow's wall-clock timeout — see `implement.ts`. */
-const MAX_TURNS = '150'
-
 /**
  * Renders `input.promptTemplate`'s `{{PLACEHOLDER}}` tokens against `input`'s
  * named fields and assembles the headless Claude CLI argument vector.
@@ -64,9 +61,9 @@ export function prepareClaudeInvocation(
   const args = [
     '--print',
     '--model',
-    CLAUDE_MODEL,
+    MODEL,
     '--max-turns',
-    MAX_TURNS,
+    String(MAX_TURNS),
     // Safe because the containment boundary is the environment, not this
     // flag: locally the agent runs inside a Docker container with no access
     // to the host, and in CI it runs on a disposable, credential-scoped

--- a/agent/implement/implement.ts
+++ b/agent/implement/implement.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path'
 import { execSync, spawn } from 'node:child_process'
 import { captureTranscript } from './transcript'
 import { prepareClaudeInvocation } from './claude-invocation'
+import { findMissingEnvVars, resolveIdleMs } from './run-policy'
 
 // Orchestrator for the `agent:implement` pipeline (#510). Spawns the Claude
 // Code CLI directly (#540 — no more `@ai-hero/sandcastle`): on CI the
@@ -11,11 +12,20 @@ import { prepareClaudeInvocation } from './claude-invocation'
 // container. The workflow owns git/PR; this script owns the agent run and the
 // runaway guards.
 
-const ISSUE_NUMBER = required('ISSUE_NUMBER')
-const ISSUE_TITLE = required('ISSUE_TITLE')
-const BRANCH = required('BRANCH')
+// Validate the whole contract-required env up front, before the Claude CLI
+// spawns, so a missing var fails immediately naming every offender instead of
+// spending tokens on a doomed run (#556).
+const missingEnv = findMissingEnvVars(process.env)
+if (missingEnv.length > 0) {
+  console.error(`Missing required env var(s): ${missingEnv.join(', ')}`)
+  process.exit(1)
+}
+
+const ISSUE_NUMBER = process.env.ISSUE_NUMBER as string
+const ISSUE_TITLE = process.env.ISSUE_TITLE as string
+const BRANCH = process.env.BRANCH as string
 /** Subscription / flat-rate token — never `ANTHROPIC_API_KEY` (metered). */
-const CLAUDE_CODE_OAUTH_TOKEN = required('CLAUDE_CODE_OAUTH_TOKEN')
+const CLAUDE_CODE_OAUTH_TOKEN = process.env.CLAUDE_CODE_OAUTH_TOKEN as string
 
 /**
  * Absolute path to the coding-standard rules (the skills repo's rules/, cloned
@@ -70,8 +80,11 @@ const { args, prompt } = prepareClaudeInvocation({
   standardsDir: STANDARDS_DIR,
   verifyReportFile: VERIFY_REPORT_FILE,
   screenshotsDir: SCREENSHOTS_DIR,
-  // Local-only (#541); unset in CI, so CI's args stay exactly as before.
-  streamOutput: process.env.AGENT_STREAM_OUTPUT === 'true'
+  // Always stream (#556): the orchestrator's idle guard below watches the
+  // CLI's output for a heartbeat, and `--print` text stays silent until the
+  // session ends. Streaming gives both adapters — CI and the local rehearsal —
+  // the same incremental signal; the local supervisor pretty-prints it.
+  streamOutput: true
 })
 
 // Never let the child fall through to a metered API key, even if the
@@ -88,22 +101,52 @@ function captureTail(chunk: Buffer) {
   outputTail = (outputTail + chunk.toString('utf8')).slice(-TAIL_BYTES)
 }
 
+// Idle runaway guard (#556): kill a stuck run once its output goes quiet for
+// the contract's idle budget (env-overridable), so a hung agent dies in minutes
+// in either adapter instead of burning the whole wall clock. Owned here because
+// the orchestrator owns the spawned CLI's stdout/stderr; the streaming above
+// keeps a healthy run's heartbeat flowing so the guard never trips on it.
+const IDLE_MS = resolveIdleMs(process.env)
+const IDLE_CHECK_INTERVAL_MS = 15_000
+let idleKilled = false
+
 // Runs in-place on the checked-out repo, so it commits directly onto BRANCH —
 // the commit-count check below relies on that.
 let exitCode: number
 try {
   exitCode = await new Promise<number>((resolve, reject) => {
     const child = spawn('claude', [...args, prompt], { env: childEnv })
+    let lastActivity = Date.now()
+    const markActive = () => {
+      lastActivity = Date.now()
+    }
     child.stdout.on('data', (chunk: Buffer) => {
       process.stdout.write(chunk)
       captureTail(chunk)
+      markActive()
     })
     child.stderr.on('data', (chunk: Buffer) => {
       process.stderr.write(chunk)
       captureTail(chunk)
+      markActive()
     })
-    child.on('error', reject)
-    child.on('close', (code) => resolve(code ?? 1))
+    const idleTimer = setInterval(() => {
+      if (Date.now() - lastActivity > IDLE_MS) {
+        idleKilled = true
+        console.error(
+          `\nFAILED: idle guard tripped after ${Math.round(IDLE_MS / 60_000)} minute(s) — killing the agent.`
+        )
+        child.kill('SIGKILL')
+      }
+    }, IDLE_CHECK_INTERVAL_MS)
+    child.on('error', (error) => {
+      clearInterval(idleTimer)
+      reject(error)
+    })
+    child.on('close', (code) => {
+      clearInterval(idleTimer)
+      resolve(code ?? 1)
+    })
   })
 } catch (error) {
   // Capture the transcript even when the CLI fails to start, so blocked runs
@@ -116,6 +159,12 @@ try {
 // Best-effort; there's exactly one session per run, so the newest-JSONL scan
 // inside captureTranscript resolves it unambiguously.
 captureTranscript({ projectsDir: PROJECTS_DIR, destPath: TRANSCRIPT_FILE })
+
+if (idleKilled) {
+  fail(
+    `Agent idle for over ${Math.round(IDLE_MS / 60_000)} minute(s) — killed by the idle guard.\n\n${outputTail}`
+  )
+}
 
 if (exitCode !== 0) {
   fail(`Claude CLI exited with status ${exitCode}.\n\n${outputTail}`)
@@ -142,15 +191,6 @@ if (!fileHasContent(PR_DESCRIPTION_FILE)) {
 }
 
 console.log(`\n${commitsAhead} commit(s) on ${BRANCH} this run.`)
-
-function required(name: string): string {
-  const value = process.env[name]
-  if (!value) {
-    console.error(`Missing required env var: ${name}`)
-    process.exit(1)
-  }
-  return value
-}
 
 function fileHasContent(file: string): boolean {
   try {

--- a/agent/implement/run-policy.test.ts
+++ b/agent/implement/run-policy.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @jest-environment node
+ */
+import {
+  CLAUDE_CODE_CLI_VERSION,
+  MAX_TURNS,
+  MODEL,
+  OPTIONAL_ENV_VARS,
+  PRESERVE_ENV_VARS,
+  REQUIRED_ENV_VARS,
+  findMissingEnvVars,
+  resolveIdleMs,
+  resolveWallClockMs,
+  runPolicyCommand
+} from './run-policy'
+
+/** A process env where every required var is present and non-empty. */
+function fullEnv(): Record<string, string | undefined> {
+  return Object.fromEntries(REQUIRED_ENV_VARS.map((name) => [name, 'set']))
+}
+
+describe('run-policy contract', () => {
+  describe('findMissingEnvVars', () => {
+    it('returns no missing names when every required var is present', () => {
+      expect(findMissingEnvVars(fullEnv())).toEqual([])
+    })
+
+    it('names every missing required var, in declaration order', () => {
+      expect(findMissingEnvVars({})).toEqual([...REQUIRED_ENV_VARS])
+    })
+
+    it('treats an empty string as missing', () => {
+      const env = fullEnv()
+      env.CLAUDE_CODE_OAUTH_TOKEN = ''
+      expect(findMissingEnvVars(env)).toEqual(['CLAUDE_CODE_OAUTH_TOKEN'])
+    })
+
+    it('ignores optional vars entirely', () => {
+      const env = fullEnv()
+      for (const name of OPTIONAL_ENV_VARS) delete env[name]
+      expect(findMissingEnvVars(env)).toEqual([])
+    })
+  })
+
+  describe('preserve-env allowlist', () => {
+    it('covers every required and optional var', () => {
+      expect(PRESERVE_ENV_VARS).toEqual([
+        ...REQUIRED_ENV_VARS,
+        ...OPTIONAL_ENV_VARS
+      ])
+    })
+
+    it('has no duplicate names', () => {
+      expect(new Set(PRESERVE_ENV_VARS).size).toBe(PRESERVE_ENV_VARS.length)
+    })
+  })
+
+  describe('budget resolution', () => {
+    it('falls back to the contract idle default when unset', () => {
+      expect(resolveIdleMs({})).toBe(15 * 60_000)
+    })
+
+    it('falls back to the contract wall-clock default when unset', () => {
+      expect(resolveWallClockMs({})).toBe(45 * 60_000)
+    })
+
+    it('honors a positive numeric env override', () => {
+      expect(resolveIdleMs({ LOCAL_IDLE_MINUTES: '3' })).toBe(3 * 60_000)
+      expect(resolveWallClockMs({ LOCAL_WALL_CLOCK_MINUTES: '20' })).toBe(
+        20 * 60_000
+      )
+    })
+
+    it('falls back when the override is empty, non-numeric, or non-positive', () => {
+      expect(resolveIdleMs({ LOCAL_IDLE_MINUTES: '' })).toBe(15 * 60_000)
+      expect(resolveIdleMs({ LOCAL_IDLE_MINUTES: 'soon' })).toBe(15 * 60_000)
+      expect(resolveIdleMs({ LOCAL_IDLE_MINUTES: '0' })).toBe(15 * 60_000)
+      expect(resolveWallClockMs({ LOCAL_WALL_CLOCK_MINUTES: '-5' })).toBe(
+        45 * 60_000
+      )
+    })
+  })
+
+  describe('CLI print mode', () => {
+    it('env-list emits the preserve-env allowlist the exports declare', () => {
+      expect(runPolicyCommand(['env-list'])).toEqual({
+        output: PRESERVE_ENV_VARS.join(',')
+      })
+    })
+
+    it('cli-version emits the pinned Claude Code CLI version', () => {
+      expect(runPolicyCommand(['cli-version'])).toEqual({
+        output: CLAUDE_CODE_CLI_VERSION
+      })
+    })
+
+    it('model emits the contract model id', () => {
+      expect(runPolicyCommand(['model'])).toEqual({ output: MODEL })
+    })
+
+    it('max-turns emits the contract max-turns cap', () => {
+      expect(runPolicyCommand(['max-turns'])).toEqual({
+        output: String(MAX_TURNS)
+      })
+    })
+
+    it('reports an error for an unknown subcommand', () => {
+      const result = runPolicyCommand(['nope'])
+      expect('error' in result).toBe(true)
+    })
+  })
+})

--- a/agent/implement/run-policy.ts
+++ b/agent/implement/run-policy.ts
@@ -1,0 +1,162 @@
+/**
+ * The single run-policy contract for the `agent:implement` pipeline (#556).
+ *
+ * Before this module the run policy both adapters must agree on — required env
+ * vars, runaway-guard budgets, model, max-turns cap, and Claude Code CLI
+ * version — was restated across the workflow, the compose file, the entrypoint's
+ * `sudo --preserve-env` allowlist, the local supervisor's defaults, and the
+ * invocation-assembly module. "Local is a faithful CI rehearsal" was an
+ * invariant maintained by hand, and it had already slipped (the CI idle guard
+ * was dropped in #540; the idle default disagreed 30-vs-10; the CLI froze at
+ * different times on each side).
+ *
+ * Every consumer now derives from here: the orchestrator validates env against
+ * {@link findMissingEnvVars} and reads the idle budget from
+ * {@link resolveIdleMs}; the local supervisor reads the wall-clock budget from
+ * {@link resolveWallClockMs}; the invocation-assembly module sources
+ * {@link MODEL} / {@link MAX_TURNS}; and the shell consumers (entrypoint,
+ * workflow install step, image build) read {@link PRESERVE_ENV_VARS} and
+ * {@link CLAUDE_CODE_CLI_VERSION} through the {@link runPolicyCommand} CLI print
+ * mode instead of duplicating them. No IO here — pure values and derivations.
+ */
+
+/** Claude model the headless agent runs. */
+export const MODEL = 'claude-opus-4-8'
+
+/**
+ * Fast-loop backstop cap on agent turns, layered on top of the idle guard and
+ * the wall-clock guard. Sourced by the invocation-assembly module.
+ */
+export const MAX_TURNS = 150
+
+/**
+ * Pinned Claude Code CLI version, consumed by both the workflow install step
+ * and the local image build so the rehearsal runs the exact CLI CI runs.
+ * Unpinned before #556, the two sides froze at different times.
+ */
+export const CLAUDE_CODE_CLI_VERSION = '2.1.208'
+
+/** Wall-clock runaway budget, in minutes. Overridable via `LOCAL_WALL_CLOCK_MINUTES`. */
+export const WALL_CLOCK_MINUTES = 45
+
+/**
+ * Idle runaway budget, in minutes. Overridable via `LOCAL_IDLE_MINUTES`.
+ * Restores the 900-second (15-minute) idle timeout #540 dropped when it removed
+ * Sandcastle; both adapters now enforce it via the orchestrator.
+ */
+export const IDLE_MINUTES = 15
+
+/**
+ * Env vars the orchestrator must see, non-empty, before it spends any tokens.
+ * A missing one aborts the run at startup naming the var (see
+ * {@link findMissingEnvVars}) instead of surfacing mid-run.
+ */
+export const REQUIRED_ENV_VARS = [
+  'ISSUE_NUMBER',
+  'ISSUE_TITLE',
+  'BRANCH',
+  // Subscription / flat-rate token — never ANTHROPIC_API_KEY (metered).
+  'CLAUDE_CODE_OAUTH_TOKEN',
+  // The integration suite + any TDD against the DB connect here.
+  'DATABASE_PRISMA_URL',
+  'DATABASE_URL_NON_POOLING',
+  // App/suite paths the agent exercises during TDD and the verify phase.
+  'NEXTAUTH_SECRET',
+  'OPENAI_API_KEY',
+  // The agent reads the issue and drives the verify flow through `gh`.
+  'GH_TOKEN'
+] as const
+
+/**
+ * Env vars the agent run consumes but can proceed without — each has a default
+ * or is a passthrough override. Present here only so the preserve-env allowlist
+ * covers them and a local `sudo` drop never silently strips them.
+ */
+export const OPTIONAL_ENV_VARS = [
+  'STANDARDS_DIR',
+  'OUTPUT_DIR',
+  'AUTH_TRUST_HOST',
+  'LOCAL_WALL_CLOCK_MINUTES',
+  'LOCAL_IDLE_MINUTES'
+] as const
+
+/**
+ * The `sudo --preserve-env` allowlist the local entrypoint must pass through:
+ * every var the run reads, required or optional. Adding a var to the contract
+ * can never again silently strip it from the local agent.
+ */
+export const PRESERVE_ENV_VARS = [
+  ...REQUIRED_ENV_VARS,
+  ...OPTIONAL_ENV_VARS
+] as const
+
+/**
+ * Names of the required env vars that are absent or empty in `env`, in
+ * declaration order. An empty array means the run may proceed.
+ */
+export function findMissingEnvVars(
+  env: Record<string, string | undefined>
+): string[] {
+  return REQUIRED_ENV_VARS.filter((name) => !env[name])
+}
+
+/** Parse a minutes override, falling back to `fallbackMinutes` unless it is a positive number. */
+function resolveMinutesMs(
+  raw: string | undefined,
+  fallbackMinutes: number
+): number {
+  const parsed = Number(raw)
+  const minutes =
+    Number.isFinite(parsed) && parsed > 0 ? parsed : fallbackMinutes
+  return minutes * 60_000
+}
+
+/** Idle budget in ms — the contract default unless `LOCAL_IDLE_MINUTES` overrides it. */
+export function resolveIdleMs(env: Record<string, string | undefined>): number {
+  return resolveMinutesMs(env.LOCAL_IDLE_MINUTES, IDLE_MINUTES)
+}
+
+/** Wall-clock budget in ms — the contract default unless `LOCAL_WALL_CLOCK_MINUTES` overrides it. */
+export function resolveWallClockMs(
+  env: Record<string, string | undefined>
+): number {
+  return resolveMinutesMs(env.LOCAL_WALL_CLOCK_MINUTES, WALL_CLOCK_MINUTES)
+}
+
+/**
+ * The CLI print mode: a shell consumer runs `bun run-policy.ts <subcommand>` to
+ * read a contract value instead of restating it. Returns the value to print, or
+ * an error string for an unknown subcommand.
+ */
+export function runPolicyCommand(
+  argv: string[]
+): { output: string } | { error: string } {
+  switch (argv[0]) {
+    case 'env-list':
+      return { output: PRESERVE_ENV_VARS.join(',') }
+    case 'cli-version':
+      return { output: CLAUDE_CODE_CLI_VERSION }
+    case 'model':
+      return { output: MODEL }
+    case 'max-turns':
+      return { output: String(MAX_TURNS) }
+    default:
+      return {
+        error: `Unknown run-policy subcommand: ${argv[0] ?? '(none)'}\nUsage: run-policy.ts <env-list|cli-version|model|max-turns>`
+      }
+  }
+}
+
+// True only when this file is the process entry (a shell consumer running
+// `bun run-policy.ts <subcommand>`), never when imported as a module — kept as
+// an argv check rather than `import.meta.main` so Jest's CJS wrapping parses it.
+const invokedAsCli = process.argv[1]?.endsWith('run-policy.ts') ?? false
+
+if (invokedAsCli) {
+  const result = runPolicyCommand(process.argv.slice(2))
+  if ('error' in result) {
+    console.error(result.error)
+    process.exit(1)
+  }
+  process.stdout.write(`${result.output}\n`)
+}

--- a/agent/local/Dockerfile
+++ b/agent/local/Dockerfile
@@ -30,14 +30,19 @@ ENV PATH="${BUN_INSTALL}/bin:${PATH}"
 RUN curl -fsSL https://bun.sh/install | bash -s "bun-v1.2.0" \
   && chmod -R a+rX "${BUN_INSTALL}"
 
-# Claude Code CLI — same install command as the `agent:implement` workflow.
-# bun's global installs never run dependency lifecycle scripts (`--trust`
-# only affects a project's package.json, not `-g`), so the postinstall that
-# fetches the real platform-native binary has to be run explicitly — without
-# it `claude` is left as a tiny stub that errors on invocation.
-RUN bun install -g @anthropic-ai/claude-code \
+# Claude Code CLI, pinned to the version the run-policy contract declares (#556)
+# — read straight from the module so the local image and CI's workflow install
+# step can never freeze at different versions. bun's global installs never run
+# dependency lifecycle scripts (`--trust` only affects a project's
+# package.json, not `-g`), so the postinstall that fetches the real
+# platform-native binary has to be run explicitly — without it `claude` is left
+# as a tiny stub that errors on invocation.
+COPY agent/implement/run-policy.ts /tmp/run-policy.ts
+RUN CLAUDE_CODE_CLI_VERSION="$(bun /tmp/run-policy.ts cli-version)" \
+  && bun install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_CLI_VERSION}" \
   && node "${BUN_INSTALL}/install/global/node_modules/@anthropic-ai/claude-code/install.cjs" \
-  && chmod -R a+rX "${BUN_INSTALL}"
+  && chmod -R a+rX "${BUN_INSTALL}" \
+  && rm /tmp/run-policy.ts
 # bun/bunx/claude resolve via /usr/local/bin regardless of PATH policy
 # (sudo's secure_path included), since dropping to the unprivileged user
 # below goes through `sudo`, which doesn't honor the custom PATH set above.
@@ -66,7 +71,6 @@ RUN useradd -m -s /bin/bash agent \
 RUN sudo -H -u agent bash -c 'cd /build && bunx playwright install chromium'
 
 COPY agent/local/entrypoint.sh /usr/local/bin/agent-local-entrypoint
-COPY agent/local/run-with-guards.ts /usr/local/bin/run-with-guards.ts
 RUN chmod +x /usr/local/bin/agent-local-entrypoint
 
 WORKDIR /workdir

--- a/agent/local/docker-compose.yml
+++ b/agent/local/docker-compose.yml
@@ -35,8 +35,11 @@ services:
       DATABASE_URL_NON_POOLING: postgresql://postgres:postgres@db:5432/recipe_chat_test
       HOST_REPO_DIR: /host-repo
       STANDARDS_DIR: /standards
-      LOCAL_WALL_CLOCK_MINUTES: ${LOCAL_WALL_CLOCK_MINUTES:-45}
-      LOCAL_IDLE_MINUTES: ${LOCAL_IDLE_MINUTES:-10}
+      # Guard budgets default in the run-policy contract (#556); these only pass
+      # a maintainer's override through — empty when unset, which the contract's
+      # resolver treats as "use the default". No idle/wall-clock number restated.
+      LOCAL_WALL_CLOCK_MINUTES: ${LOCAL_WALL_CLOCK_MINUTES:-}
+      LOCAL_IDLE_MINUTES: ${LOCAL_IDLE_MINUTES:-}
     volumes:
       # Only the git object/ref database — never the host's working tree, so
       # the container has no visibility into uncommitted changes, .env files,

--- a/agent/local/entrypoint.sh
+++ b/agent/local/entrypoint.sh
@@ -55,10 +55,6 @@ else
 fi
 
 export ISSUE_NUMBER ISSUE_TITLE BRANCH CLAUDE_CODE_OAUTH_TOKEN
-# Headless `--print` text output is silent until the whole session ends,
-# which would starve the idle guard below of any signal — switch to
-# streaming JSON locally only (implement.ts / claude-invocation.ts, #541).
-export AGENT_STREAM_OUTPUT=true
 
 # Everything above runs as root (simplest for the bind-mounted-.git push
 # below). Claude Code CLI itself refuses `--dangerously-skip-permissions` as
@@ -76,10 +72,13 @@ echo "==> Ensuring the Playwright browser matches this checkout's pinned version
 sudo -H -u agent bash -c "cd '$WORKDIR' && bunx playwright install chromium"
 
 echo "==> Running the implementation agent (shared orchestrator, #540)"
+# Derive the sudo --preserve-env allowlist from the run-policy contract (#556)
+# so adding an env var can never silently strip it from the local agent.
+PRESERVE_ENV="$(bun agent/implement/run-policy.ts env-list)"
 set +e
 sudo -H -u agent \
-  --preserve-env=ISSUE_NUMBER,ISSUE_TITLE,BRANCH,CLAUDE_CODE_OAUTH_TOKEN,STANDARDS_DIR,OUTPUT_DIR,DATABASE_PRISMA_URL,DATABASE_URL_NON_POOLING,NEXTAUTH_SECRET,OPENAI_API_KEY,AUTH_TRUST_HOST,GH_TOKEN,AGENT_STREAM_OUTPUT \
-  bash -c "cd '$WORKDIR' && bun /usr/local/bin/run-with-guards.ts"
+  --preserve-env="$PRESERVE_ENV" \
+  bash -c "cd '$WORKDIR' && bun agent/local/run-with-guards.ts"
 AGENT_EXIT_CODE=$?
 set -e
 

--- a/agent/local/run-with-guards.ts
+++ b/agent/local/run-with-guards.ts
@@ -1,34 +1,31 @@
 import { spawn } from 'node:child_process'
+import { resolveWallClockMs } from '../implement/run-policy'
 
 /**
- * Local-only runaway guards for `agent:local` (#541): a wall-clock cap and an
- * idle cap on top of `implement.ts`'s own `--max-turns` cap. CI already has
- * an equivalent wall-clock via the workflow's `timeout-minutes: 45`; a local
- * run has no workflow wrapping it, so this process supervises the same two
- * failure modes (a slow-but-still-working run, and a fully stuck one)
- * itself. Not unit-tested — a thin IO/process wrapper, verified by running,
- * matching how the repo treats the rest of its agent-pipeline IO scripts.
+ * Local-only wall-clock guard for `agent:local` (#541, #556): a hard cap on the
+ * whole run on top of `implement.ts`'s own `--max-turns` cap and the idle guard
+ * the orchestrator now owns (#556 — so both adapters share it). CI already has
+ * an equivalent wall-clock via the workflow's `timeout-minutes`; a local run has
+ * no workflow wrapping it, so this process supervises the slow-but-still-working
+ * failure mode itself. The budget comes from the run-policy contract
+ * (env-overridable). Not unit-tested — a thin IO/process wrapper, verified by
+ * running, matching how the repo treats the rest of its agent-pipeline IO
+ * scripts.
  */
 
-const WALL_CLOCK_MS =
-  Number(process.env.LOCAL_WALL_CLOCK_MINUTES ?? '45') * 60_000
-const IDLE_MS = Number(process.env.LOCAL_IDLE_MINUTES ?? '30') * 60_000
-const IDLE_CHECK_INTERVAL_MS = 15_000
+const WALL_CLOCK_MS = resolveWallClockMs(process.env)
 
 const child = spawn('bun', ['agent/implement/implement.ts'], {
   stdio: ['inherit', 'pipe', 'pipe']
 })
 
-let lastActivity = Date.now()
-
-// implement.ts sets AGENT_STREAM_OUTPUT (below), which switches the CLI to
-// `--output-format stream-json`: one JSON event per line instead of a single
-// blob printed at the very end. Pretty-print the events worth showing;
-// anything unrecognized still passes through raw rather than getting
-// swallowed, so a schema drift degrades to noisier output, never to silence.
+// implement.ts streams the CLI as `--output-format stream-json` (#556): one
+// JSON event per line instead of a single blob printed at the very end.
+// Pretty-print the events worth showing; anything unrecognized still passes
+// through raw rather than getting swallowed, so a schema drift degrades to
+// noisier output, never to silence.
 let stdoutBuffer = ''
 child.stdout.on('data', (chunk: Buffer) => {
-  lastActivity = Date.now()
   stdoutBuffer += chunk.toString('utf8')
   const lines = stdoutBuffer.split('\n')
   stdoutBuffer = lines.pop() ?? ''
@@ -36,7 +33,6 @@ child.stdout.on('data', (chunk: Buffer) => {
 })
 child.stderr.on('data', (chunk: Buffer) => {
   process.stderr.write(chunk)
-  lastActivity = Date.now()
 })
 
 function printStreamEvent(line: string) {
@@ -90,17 +86,12 @@ const wallClockTimer = setTimeout(
   () => killForTimeout('wall-clock', WALL_CLOCK_MS),
   WALL_CLOCK_MS
 )
-const idleInterval = setInterval(() => {
-  const idleFor = Date.now() - lastActivity
-  if (idleFor > IDLE_MS) killForTimeout('idle', IDLE_MS)
-}, IDLE_CHECK_INTERVAL_MS)
 
 const exitCode: number = await new Promise((resolve) => {
   child.on('close', (code) => resolve(code ?? 1))
 })
 
 clearTimeout(wallClockTimer)
-clearInterval(idleInterval)
 
 // A guard kill still exits non-zero via the child's own SIGKILL exit code,
 // but make the reason unambiguous in the log regardless of that exit code.


### PR DESCRIPTION
Closes #556

## What & why

The `agent:implement` pipeline runs through two adapters — the CI ephemeral
runner and the local Docker rehearsal — but the run policy both must agree on
was declared independently in 4+ places (workflow env, compose, entrypoint's
`--preserve-env`, the local supervisor's defaults, the invocation module). That
hand-maintained "local is a faithful CI rehearsal" invariant had already
slipped: CI lost its idle guard in #540, the idle default disagreed (30 vs 10),
and the CLI was unpinned but frozen at different times on each side.

This reunifies the contract into one pure module that every consumer derives
from.

### New: `agent/implement/run-policy.ts`

Owns required/optional env var names, the model id, the max-turns cap, the
wall-clock and idle budgets, and the pinned Claude Code CLI version. Exports an
env-validation function, a `--preserve-env` allowlist derivation, budget
resolvers (contract default + env override), and a CLI print mode
(`env-list` / `cli-version` / `model` / `max-turns`) so shell consumers read
values instead of restating them.

### Consumers now derive from it

- **Orchestrator (`implement.ts`)** validates the contract-required env up front
  — a missing var aborts before the CLI spawns, naming every offender (AC 2, 9)
  — and now **owns the idle guard**, restored in CI (AC 4). It's fed by
  always-on streaming so a healthy run keeps a heartbeat and a hung run dies at
  the idle budget in either adapter instead of burning the 45-min wall clock.
- **Local supervisor (`run-with-guards.ts`)** drops its now-redundant idle
  logic, keeps wall-clock supervision + stream pretty-printing, and sources the
  wall-clock budget from the contract (AC 5, 10).
- **Entrypoint** derives its `sudo --preserve-env` list from the contract, so
  adding an env var can never silently strip it from local runs (AC 3). This
  also fixes a latent bug: `LOCAL_*` overrides were never in the old allowlist,
  so they were silently stripped under the sudo drop — now they pass through
  (AC 11).
- **Compose** stops declaring its own idle default; both budgets pass through as
  overrides, defaulting in the contract (AC 5, 11).
- **Workflow install step + local image build** install the pinned CLI version
  read from the contract, so the rehearsal runs the same CLI as CI (AC 6).
- **Invocation-assembly module** sources model + max-turns from the contract
  (AC 7); its interface is unchanged.

## How it's tested

- New colocated `run-policy.test.ts` (15 cases) covers the contract's external
  interface only: env validation, allowlist derivation, budget resolution
  (override + fallbacks), and CLI print mode (AC 8).
- Extended `claude-invocation.test.ts` to assert the model/max-turns flags come
  from the contract.
- Full gate green: typecheck, lint, format, `bun run test` (184 tests pass).
- Thin IO consumers verified by running (env-list/cli-version print modes; the
  empty-env startup abort; `bash -n` on the shell scripts; YAML parses).

## Reviewer notes

- **CI job-log format changes**: streaming is now unconditional so the idle
  guard has a heartbeat in CI (text `--print` is silent until the session ends,
  which would make the idle guard kill healthy runs). CI logs — and the failure
  tail — are now raw `stream-json` lines; the local supervisor still
  pretty-prints. This is the mechanism the idle guard needs; no prompt/verify/PR
  behavior changes.
- **Idle default is 15 min**, restoring Sandcastle's 900-second timeout #540
  dropped (local was effectively 10 via compose; healthy runs are unaffected
  either way since the guard only trips on silence).
- **`AGENT_STREAM_OUTPUT` removed** (streaming is now always on), so its
  plumbing is gone from the entrypoint and the preserve-env list.
- Not run here: the `bun run agent:local <issue>` Docker rehearsal (needs Docker
  + a subscription token). Out of scope per the issue: trajectory evals, hooks
  injection, mounting the output dir, prompt/preflight/verify content changes.
