### PR TITLE
chore: update Playwright config and refactor screenshot handling

### DIFF
--- a/e2e/fab-stack.spec.ts
+++ b/e2e/fab-stack.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { verifyShot } from './verify-shot'
 
 /**
  * Issue #542 — shared, animated FAB stack.
@@ -19,11 +20,15 @@ test('stacks the Edit and chat FABs and preserves their click behavior', async (
   page
 }) => {
   const shot = (name: string) =>
-    page.screenshot({ path: `.agent/verify/issue-542/${name}.png` })
+    verifyShot(page, `.agent/verify/issue-542/${name}.png`)
 
-  // Open the seeded recipe's detail page (alice@prisma.io has one recipe).
+  // Open the seeded recipe's detail page (alice@prisma.io has one recipe). The
+  // recipe also appears in the "Recent" strip, so disambiguate with `.first()`.
   await page.goto('/recipes')
-  await page.getByText('CREAMY MUSHROOM TOAST', { exact: false }).click()
+  await page
+    .getByText('CREAMY MUSHROOM TOAST', { exact: false })
+    .first()
+    .click()
   await page.waitForURL(/\/recipes\/.+/)
 
   // Both FABs coexist in the shared stack — no page computes the other's offset.
@@ -42,11 +47,14 @@ test('stacks the Edit and chat FABs and preserves their click behavior', async (
 
   // Wait for the stack's entrance animation (route-transition delay + fade) to
   // settle so the proof shot shows the fully-opaque FABs, not a mid-fade frame.
+  // Poll as a float — a mid-transition sample can land at e.g. 0.999932.
   await expect
     .poll(() =>
-      editFab.evaluate((el) => getComputedStyle(el.parentElement!).opacity)
+      editFab.evaluate((el) =>
+        Number(getComputedStyle(el.parentElement!).opacity)
+      )
     )
-    .toBe('1')
+    .toBeGreaterThan(0.99)
   await shot('stacked-fabs')
 
   // Click behavior is unchanged: the Edit FAB still flips into inline edit mode.

--- a/e2e/recipe-chat-tools.spec.ts
+++ b/e2e/recipe-chat-tools.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { verifyShot } from './verify-shot'
 
 /**
  * Issue #458 — AI tool calling: the chat can edit the recipe and add notes when
@@ -54,8 +55,7 @@ test('chat adds a note to the recipe from its detail page', async ({
     timeout: ACTION_TIMEOUT
   })
 
-  await page.screenshot({
-    path: '.agent/verify/issue-458/add-note-confirmation.png',
+  await verifyShot(page, '.agent/verify/issue-458/add-note-confirmation.png', {
     fullPage: true
   })
 })
@@ -72,8 +72,9 @@ test('chat edits the recipe from its detail page', async ({ page }) => {
     timeout: ACTION_TIMEOUT
   })
 
-  await page.screenshot({
-    path: '.agent/verify/issue-458/edit-recipe-confirmation.png',
-    fullPage: true
-  })
+  await verifyShot(
+    page,
+    '.agent/verify/issue-458/edit-recipe-confirmation.png',
+    { fullPage: true }
+  )
 })

--- a/e2e/recipe-detail-auth.spec.ts
+++ b/e2e/recipe-detail-auth.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { verifyShot } from './verify-shot'
 
 /**
  * Issue #545 — the Recipe detail page threw a swallowed `UNAUTHORIZED` on every
@@ -15,7 +16,7 @@ test('loads the Recipe detail page for an authed user with no UNAUTHORIZED', asy
   page
 }) => {
   const shot = (name: string) =>
-    page.screenshot({ path: `.agent/verify/issue-545/${name}.png` })
+    verifyShot(page, `.agent/verify/issue-545/${name}.png`)
 
   // Collect anything that would signal the #545 fault: a console error naming
   // the auth failure, or a failed `recipes.bySlug` HTTP response.
@@ -30,9 +31,13 @@ test('loads the Recipe detail page for an authed user with no UNAUTHORIZED', asy
     }
   })
 
-  // Find the seeded recipe from the list and capture its detail URL.
+  // Find the seeded recipe from the list and capture its detail URL. It also
+  // appears in the "Recent" strip, so disambiguate with `.first()`.
   await page.goto('/recipes')
-  await page.getByText('CREAMY MUSHROOM TOAST', { exact: false }).click()
+  await page
+    .getByText('CREAMY MUSHROOM TOAST', { exact: false })
+    .first()
+    .click()
   await page.waitForURL(/\/recipes\/.+/)
   const detailUrl = page.url()
 

--- a/e2e/recipe-edit.spec.ts
+++ b/e2e/recipe-edit.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { verifyShot } from './verify-shot'
 
 /**
  * Issue #526 — inline edit mode on the Recipe detail page plus editable Facets.
@@ -12,11 +13,15 @@ test('inline-edits a Recipe and surfaces its Facets as badges', async ({
   page
 }) => {
   const shot = (name: string) =>
-    page.screenshot({ path: `.agent/verify/issue-526/${name}.png` })
+    verifyShot(page, `.agent/verify/issue-526/${name}.png`)
 
-  // Open the seeded recipe's detail page.
+  // Open the seeded recipe's detail page. It also appears in the "Recent"
+  // strip, so disambiguate with `.first()`.
   await page.goto('/recipes')
-  await page.getByText('CREAMY MUSHROOM TOAST', { exact: false }).click()
+  await page
+    .getByText('CREAMY MUSHROOM TOAST', { exact: false })
+    .first()
+    .click()
   await page.waitForURL(/\/recipes\/.+/)
 
   // Reading view: the inline Edit button is visible; with no Facets yet, no

--- a/e2e/recipes.spec.ts
+++ b/e2e/recipes.spec.ts
@@ -11,9 +11,9 @@ test('authenticated user sees their seeded recipe on /recipes', async ({
 }) => {
   await page.goto('/recipes')
 
-  // The seeded user (alice@prisma.io) has one recipe; its name renders as a
-  // heading on the recipes grid.
+  // The seeded user (alice@prisma.io) has one recipe; its name renders both in
+  // the main grid and the "Recent" strip, so disambiguate with `.first()`.
   await expect(
-    page.getByText('CREAMY MUSHROOM TOAST', { exact: false })
+    page.getByText('CREAMY MUSHROOM TOAST', { exact: false }).first()
   ).toBeVisible()
 })

--- a/e2e/smart-shopping-list.spec.ts
+++ b/e2e/smart-shopping-list.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from '@playwright/test'
+import { verifyShot } from './verify-shot'
 
 /**
  * Smart Shopping List (#417). Drives the real app as the seeded user to prove
@@ -89,7 +90,7 @@ test('merges ingredients across units, keeps "to taste" separate, and edits tota
   await expect(page.getByText('salt to taste', { exact: false })).toBeVisible()
   await expect(page.getByRole('spinbutton', { name: /salt/i })).toHaveCount(0)
 
-  await page.screenshot({ path: `${SCREENSHOT_DIR}/merged-and-edge-cases.png` })
+  await verifyShot(page, `${SCREENSHOT_DIR}/merged-and-edge-cases.png`)
 
   // AC4: manually adjust a merged/measured total and confirm it persists.
   const sugarQty = page.getByRole('spinbutton', { name: /sugar/i })
@@ -104,5 +105,5 @@ test('merges ingredients across units, keeps "to taste" separate, and edits tota
   const sugarAfter = page.getByRole('spinbutton', { name: /sugar/i })
   await expect(sugarAfter).toHaveValue('12')
 
-  await page.screenshot({ path: `${SCREENSHOT_DIR}/manual-adjust.png` })
+  await verifyShot(page, `${SCREENSHOT_DIR}/manual-adjust.png`)
 })

--- a/e2e/verify-shot.ts
+++ b/e2e/verify-shot.ts
@@ -1,0 +1,15 @@
+import type { Page } from '@playwright/test'
+
+/**
+ * Writes an agent-verify screenshot, but only on CI — where an agent is
+ * gathering evidence for a PR. Local `bun run test:e2e` runs stay silent so
+ * they don't litter `.agent/verify/issue-<N>/` on every run.
+ */
+export async function verifyShot(
+  page: Page,
+  path: string,
+  opts?: { fullPage?: boolean }
+) {
+  if (!process.env.CI) return
+  await page.screenshot({ path, fullPage: opts?.fullPage })
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,13 +37,21 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  // All specs act on the same single seeded user/recipe, and two specs make a
+  // live LLM call; letting files run in parallel contends on both (DB races,
+  // model rate limits), causing sporadic timeouts. One worker keeps the whole
+  // suite as serial as recipe-chat-tools.spec.ts already requires of itself.
+  workers: 1,
 
   use: {
     baseURL: BASE_URL,
     // Proof is a built-in: capture a screenshot for every test, a trace on the
-    // first retry, and video only when a test fails. Agent specs additionally
-    // take explicit `page.screenshot()` shots into `.agent/verify/issue-<N>/`.
-    screenshot: 'on',
+    // first retry, and video only when a test fails. Screenshots are only
+    // useful when an agent is gathering evidence for a PR, so keep them
+    // CI-only — otherwise every local `bun run test:e2e` litters
+    // test-results/. Agent specs additionally take explicit screenshots via
+    // `verifyShot` (see `e2e/verify-shot.ts`), gated the same way.
+    screenshot: process.env.CI ? 'on' : 'off',
     trace: 'on-first-retry',
     video: 'retain-on-failure'
   },


### PR DESCRIPTION
- Set the number of workers to 1 in Playwright config to avoid race conditions during parallel test execution.
- Introduced a new `verifyShot` function to handle screenshots conditionally based on the CI environment, preventing local runs from cluttering the results directory.
- Updated multiple test files to utilize `verifyShot` instead of direct screenshot calls, ensuring consistent behavior across environments.