### PR TITLE
One handleStripeEvent seam: test the subscription money path with fixture events

### DIFF
--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -1,13 +1,9 @@
 import { type NextRequest, NextResponse } from 'next/server'
+import type Stripe from 'stripe'
 import { getStripe } from '~/lib/stripe'
 import { prisma } from '~/server/db'
-import {
-  handleSubscriptionCreated,
-  handleSubscriptionUpdated,
-  handleSubscriptionDeleted,
-  handlePaymentFailed
-} from '~/server/api/use-cases/subscription-use-case'
-import type Stripe from 'stripe'
+import { SubscriptionAccess } from '~/server/api/data-access/subscription-access'
+import { handleStripeEvent } from '~/server/api/use-cases/subscription-use-case'
 
 export async function POST(req: NextRequest) {
   const body = await req.text()
@@ -17,9 +13,11 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Missing signature' }, { status: 400 })
   }
 
+  const stripe = getStripe()
+
   let event: Stripe.Event
   try {
-    event = getStripe().webhooks.constructEvent(
+    event = stripe.webhooks.constructEvent(
       body,
       signature,
       process.env.STRIPE_WEBHOOK_SECRET
@@ -27,33 +25,11 @@ export async function POST(req: NextRequest) {
   } catch {
     return NextResponse.json({ error: 'Invalid signature' }, { status: 400 })
   }
-  console.log('event.type', event.type)
-  switch (event.type) {
-    case 'customer.subscription.created':
-      await handleSubscriptionCreated(
-        event.data.object as Stripe.Subscription,
-        prisma
-      )
-      break
 
-    case 'customer.subscription.updated':
-      await handleSubscriptionUpdated(
-        event.data.object as Stripe.Subscription,
-        prisma
-      )
-      break
-
-    case 'customer.subscription.deleted':
-      await handleSubscriptionDeleted(
-        event.data.object as Stripe.Subscription,
-        prisma
-      )
-      break
-
-    case 'invoice.payment_failed':
-      await handlePaymentFailed(event.data.object as Stripe.Invoice, prisma)
-      break
-  }
+  await handleStripeEvent(event, {
+    stripe,
+    access: new SubscriptionAccess(prisma)
+  })
 
   return NextResponse.json({ received: true })
 }

--- a/src/server/api/data-access/subscription-access.ts
+++ b/src/server/api/data-access/subscription-access.ts
@@ -1,8 +1,44 @@
 import { type SubscriptionTier, type SubscriptionStatus } from '@prisma/client'
 import { DataAccess } from './data-access'
 
-export class SubscriptionAccess extends DataAccess {
-  async getUserByStripeCustomerId(customerId: string) {
+/** The user fields the Stripe webhook path reads to resolve and update a subscription. */
+export type SubscriptionEventUser = {
+  id: string
+  stripeCustomerId: string | null
+  stripeSubscriptionId: string | null
+  subscriptionTier: SubscriptionTier
+  subscriptionStatus: SubscriptionStatus | null
+}
+
+export type UpdateSubscriptionData = {
+  stripeSubscriptionId?: string | null
+  subscriptionTier: SubscriptionTier
+  subscriptionStatus: SubscriptionStatus | null
+  currentPeriodEnd?: Date | null
+}
+
+/**
+ * The data-access seam the Stripe webhook path depends on. Production uses the
+ * Prisma-backed `SubscriptionAccess`; tests substitute an in-memory fake so the
+ * subscription money path is exercised with no database and no network.
+ */
+export interface SubscriptionEventAccess {
+  getUserByStripeCustomerId(
+    customerId: string
+  ): Promise<SubscriptionEventUser | null>
+  updateSubscription(
+    userId: string,
+    data: UpdateSubscriptionData
+  ): Promise<unknown>
+}
+
+export class SubscriptionAccess
+  extends DataAccess
+  implements SubscriptionEventAccess
+{
+  async getUserByStripeCustomerId(
+    customerId: string
+  ): Promise<SubscriptionEventUser | null> {
     return await this.prisma.user.findUnique({
       where: { stripeCustomerId: customerId },
       select: {
@@ -22,15 +58,7 @@ export class SubscriptionAccess extends DataAccess {
     })
   }
 
-  async updateSubscription(
-    userId: string,
-    data: {
-      stripeSubscriptionId?: string | null
-      subscriptionTier: SubscriptionTier
-      subscriptionStatus: SubscriptionStatus | null
-      currentPeriodEnd?: Date | null
-    }
-  ) {
+  async updateSubscription(userId: string, data: UpdateSubscriptionData) {
     return await this.prisma.user.update({
       where: { id: userId },
       data

--- a/src/server/api/routers/subscription-router.ts
+++ b/src/server/api/routers/subscription-router.ts
@@ -5,6 +5,7 @@ import {
   getSubscriptionInfo
 } from '~/server/api/use-cases/subscription-use-case'
 import { createCheckoutSchema } from '~/schemas/subscription-schema'
+import { getStripe } from '~/lib/stripe'
 
 export const subscriptionRouter = createTRPCRouter({
   getInfo: protectedProcedure.query(async ({ ctx }) => {
@@ -14,10 +15,19 @@ export const subscriptionRouter = createTRPCRouter({
   createCheckout: protectedProcedure
     .input(createCheckoutSchema)
     .mutation(async ({ input, ctx }) => {
-      return await createCheckoutSession(ctx.session.user.id, input, ctx.prisma)
+      return await createCheckoutSession(
+        ctx.session.user.id,
+        input,
+        ctx.prisma,
+        getStripe()
+      )
     }),
 
   createPortalSession: protectedProcedure.mutation(async ({ ctx }) => {
-    return await createPortalSession(ctx.session.user.id, ctx.prisma)
+    return await createPortalSession(
+      ctx.session.user.id,
+      ctx.prisma,
+      getStripe()
+    )
   })
 })

--- a/src/server/api/use-cases/subscription-use-case.fixtures.ts
+++ b/src/server/api/use-cases/subscription-use-case.fixtures.ts
@@ -1,0 +1,102 @@
+import type Stripe from 'stripe'
+
+/**
+ * Trimmed Stripe event payloads — only the fields `handleStripeEvent` reads.
+ * These stand in for recorded webhook deliveries so the money path is exercised
+ * with no Stripe account and no network. The price ids below must match the
+ * `~/lib/stripe-config` mock in the colocated test.
+ */
+
+export const TEST_CUSTOMER_ID = 'cus_TEST_alice'
+export const UNKNOWN_CUSTOMER_ID = 'cus_TEST_nobody'
+export const STARTER_PRICE_ID = 'price_starter_test'
+export const PREMIUM_PRICE_ID = 'price_premium_test'
+export const UNKNOWN_PRICE_ID = 'price_unmapped_test'
+
+/** Fixed Unix seconds so the persisted `currentPeriodEnd` Date is deterministic. */
+export const PERIOD_END_UNIX = 1782000000
+
+type SubscriptionOverrides = {
+  id?: string
+  customer?: string
+  priceId?: string
+  status?: Stripe.Subscription.Status
+  currentPeriodEnd?: number | null
+}
+
+function subscription(
+  overrides: SubscriptionOverrides = {}
+): Stripe.Subscription {
+  const {
+    id = 'sub_TEST123',
+    customer = TEST_CUSTOMER_ID,
+    priceId = STARTER_PRICE_ID,
+    status = 'active',
+    currentPeriodEnd = PERIOD_END_UNIX
+  } = overrides
+
+  return {
+    id,
+    object: 'subscription',
+    customer,
+    status,
+    items: {
+      object: 'list',
+      data: [
+        {
+          id: 'si_TEST123',
+          object: 'subscription_item',
+          current_period_end: currentPeriodEnd,
+          price: { id: priceId, object: 'price' }
+        }
+      ]
+    }
+  } as unknown as Stripe.Subscription
+}
+
+function invoice(overrides: { customer?: string | null } = {}): Stripe.Invoice {
+  const { customer = TEST_CUSTOMER_ID } = overrides
+  return {
+    id: 'in_TEST123',
+    object: 'invoice',
+    customer
+  } as unknown as Stripe.Invoice
+}
+
+function event(type: string, object: unknown): Stripe.Event {
+  return {
+    id: 'evt_TEST123',
+    object: 'event',
+    type,
+    data: { object }
+  } as unknown as Stripe.Event
+}
+
+export function subscriptionCreatedEvent(
+  overrides: SubscriptionOverrides = {}
+) {
+  return event('customer.subscription.created', subscription(overrides))
+}
+
+export function subscriptionUpdatedEvent(
+  overrides: SubscriptionOverrides = {}
+) {
+  return event('customer.subscription.updated', subscription(overrides))
+}
+
+export function subscriptionDeletedEvent(
+  overrides: SubscriptionOverrides = {}
+) {
+  return event('customer.subscription.deleted', subscription(overrides))
+}
+
+export function paymentFailedEvent(
+  overrides: { customer?: string | null } = {}
+) {
+  return event('invoice.payment_failed', invoice(overrides))
+}
+
+/** An event type the webhook does not handle — must be an explicit no-op. */
+export function unhandledEvent() {
+  return event('payment_intent.succeeded', { id: 'pi_TEST123' })
+}

--- a/src/server/api/use-cases/subscription-use-case.test.ts
+++ b/src/server/api/use-cases/subscription-use-case.test.ts
@@ -1,0 +1,250 @@
+/**
+ * @jest-environment node
+ */
+import type Stripe from 'stripe'
+import {
+  handleStripeEvent,
+  type HandleStripeEventResult
+} from '~/server/api/use-cases/subscription-use-case'
+import type {
+  SubscriptionEventAccess,
+  SubscriptionEventUser,
+  UpdateSubscriptionData
+} from '~/server/api/data-access/subscription-access'
+import {
+  PERIOD_END_UNIX,
+  PREMIUM_PRICE_ID,
+  STARTER_PRICE_ID,
+  TEST_CUSTOMER_ID,
+  UNKNOWN_CUSTOMER_ID,
+  UNKNOWN_PRICE_ID,
+  paymentFailedEvent,
+  subscriptionCreatedEvent,
+  subscriptionDeletedEvent,
+  subscriptionUpdatedEvent,
+  unhandledEvent
+} from '~/server/api/use-cases/subscription-use-case.fixtures'
+
+// The real price->tier map is built from env at import time; pin it to the
+// fixture price ids so the resolution rule is deterministic with no Stripe env.
+jest.mock('~/lib/stripe-config', () => ({
+  PRICE_ID_TO_TIER: {
+    price_starter_test: 'STARTER',
+    price_premium_test: 'PREMIUM'
+  },
+  TIER_TO_PRICE_ID: {
+    STARTER: 'price_starter_test',
+    PREMIUM: 'price_premium_test'
+  }
+}))
+
+/** In-memory adapter implementing the data-access seam — the test-side port. */
+class FakeSubscriptionAccess implements SubscriptionEventAccess {
+  private readonly usersByCustomer = new Map<string, SubscriptionEventUser>()
+  readonly writes: Array<{ userId: string; data: UpdateSubscriptionData }> = []
+
+  seed(user: SubscriptionEventUser) {
+    if (user.stripeCustomerId)
+      this.usersByCustomer.set(user.stripeCustomerId, user)
+    return this
+  }
+
+  async getUserByStripeCustomerId(customerId: string) {
+    return this.usersByCustomer.get(customerId) ?? null
+  }
+
+  async updateSubscription(userId: string, data: UpdateSubscriptionData) {
+    this.writes.push({ userId, data })
+    return undefined
+  }
+
+  get lastWrite() {
+    return this.writes[this.writes.length - 1]
+  }
+}
+
+// handleStripeEvent never touches the Stripe client on the webhook path; a bare
+// stub proves the seam accepts an injected client without any network.
+const fakeStripe = {} as unknown as Stripe
+
+function knownUser(
+  overrides: Partial<SubscriptionEventUser> = {}
+): SubscriptionEventUser {
+  return {
+    id: 'user_alice',
+    stripeCustomerId: TEST_CUSTOMER_ID,
+    stripeSubscriptionId: null,
+    subscriptionTier: 'FREE',
+    subscriptionStatus: null,
+    ...overrides
+  }
+}
+
+function run(event: Stripe.Event, access: FakeSubscriptionAccess) {
+  return handleStripeEvent(event, { stripe: fakeStripe, access })
+}
+
+describe('handleStripeEvent', () => {
+  describe('checkout completed (customer.subscription.created)', () => {
+    it('activates the paid tier with the subscription id and period end', async () => {
+      const access = new FakeSubscriptionAccess().seed(knownUser())
+
+      const result = await run(
+        subscriptionCreatedEvent({ priceId: STARTER_PRICE_ID }),
+        access
+      )
+
+      expect(result).toEqual<HandleStripeEventResult>({
+        status: 'updated',
+        userId: 'user_alice'
+      })
+      expect(access.lastWrite).toEqual({
+        userId: 'user_alice',
+        data: {
+          stripeSubscriptionId: 'sub_TEST123',
+          subscriptionTier: 'STARTER',
+          subscriptionStatus: 'ACTIVE',
+          currentPeriodEnd: new Date(PERIOD_END_UNIX * 1000)
+        }
+      })
+    })
+  })
+
+  describe('plan change (customer.subscription.updated)', () => {
+    it('updates the tier, status, and period end to match the new plan', async () => {
+      const access = new FakeSubscriptionAccess().seed(
+        knownUser({ subscriptionTier: 'STARTER', subscriptionStatus: 'ACTIVE' })
+      )
+
+      const result = await run(
+        subscriptionUpdatedEvent({
+          priceId: PREMIUM_PRICE_ID,
+          status: 'active'
+        }),
+        access
+      )
+
+      expect(result).toEqual<HandleStripeEventResult>({
+        status: 'updated',
+        userId: 'user_alice'
+      })
+      expect(access.lastWrite.data).toMatchObject({
+        subscriptionTier: 'PREMIUM',
+        subscriptionStatus: 'ACTIVE'
+      })
+    })
+
+    it('marks a non-active subscription INCOMPLETE', async () => {
+      const access = new FakeSubscriptionAccess().seed(knownUser())
+
+      await run(
+        subscriptionUpdatedEvent({
+          priceId: PREMIUM_PRICE_ID,
+          status: 'past_due'
+        }),
+        access
+      )
+
+      expect(access.lastWrite.data.subscriptionStatus).toBe('INCOMPLETE')
+    })
+  })
+
+  describe('cancellation (customer.subscription.deleted)', () => {
+    it('downgrades to FREE, CANCELED, clearing the subscription and period', async () => {
+      const access = new FakeSubscriptionAccess().seed(
+        knownUser({
+          subscriptionTier: 'PREMIUM',
+          subscriptionStatus: 'ACTIVE',
+          stripeSubscriptionId: 'sub_TEST123'
+        })
+      )
+
+      const result = await run(subscriptionDeletedEvent(), access)
+
+      expect(result).toEqual<HandleStripeEventResult>({
+        status: 'updated',
+        userId: 'user_alice'
+      })
+      expect(access.lastWrite.data).toEqual({
+        stripeSubscriptionId: null,
+        subscriptionTier: 'FREE',
+        subscriptionStatus: 'CANCELED',
+        currentPeriodEnd: null
+      })
+    })
+  })
+
+  describe('payment failed (invoice.payment_failed)', () => {
+    it('sets PAST_DUE while preserving the current tier', async () => {
+      const access = new FakeSubscriptionAccess().seed(
+        knownUser({ subscriptionTier: 'PREMIUM', subscriptionStatus: 'ACTIVE' })
+      )
+
+      const result = await run(paymentFailedEvent(), access)
+
+      expect(result).toEqual<HandleStripeEventResult>({
+        status: 'updated',
+        userId: 'user_alice'
+      })
+      expect(access.lastWrite.data).toEqual({
+        subscriptionTier: 'PREMIUM',
+        subscriptionStatus: 'PAST_DUE'
+      })
+    })
+  })
+
+  describe('explicit no-ops', () => {
+    it('ignores an event for an unknown customer without writing', async () => {
+      const access = new FakeSubscriptionAccess().seed(knownUser())
+
+      const result = await run(
+        subscriptionCreatedEvent({ customer: UNKNOWN_CUSTOMER_ID }),
+        access
+      )
+
+      expect(result).toEqual<HandleStripeEventResult>({
+        status: 'ignored',
+        reason: 'unknown_customer'
+      })
+      expect(access.writes).toHaveLength(0)
+    })
+
+    it('ignores an invoice with no customer without writing', async () => {
+      const access = new FakeSubscriptionAccess().seed(knownUser())
+
+      const result = await run(paymentFailedEvent({ customer: null }), access)
+
+      expect(result).toEqual<HandleStripeEventResult>({
+        status: 'ignored',
+        reason: 'unknown_customer'
+      })
+      expect(access.writes).toHaveLength(0)
+    })
+
+    it('ignores an unhandled event type without writing', async () => {
+      const access = new FakeSubscriptionAccess().seed(knownUser())
+
+      const result = await run(unhandledEvent(), access)
+
+      expect(result).toEqual<HandleStripeEventResult>({
+        status: 'ignored',
+        reason: 'unhandled_event'
+      })
+      expect(access.writes).toHaveLength(0)
+    })
+  })
+
+  describe('price -> tier resolution', () => {
+    it.each([
+      [STARTER_PRICE_ID, 'STARTER'],
+      [PREMIUM_PRICE_ID, 'PREMIUM'],
+      [UNKNOWN_PRICE_ID, 'FREE']
+    ])('maps price %s to tier %s', async (priceId, tier) => {
+      const access = new FakeSubscriptionAccess().seed(knownUser())
+
+      await run(subscriptionCreatedEvent({ priceId }), access)
+
+      expect(access.lastWrite.data.subscriptionTier).toBe(tier)
+    })
+  })
+})

--- a/src/server/api/use-cases/subscription-use-case.ts
+++ b/src/server/api/use-cases/subscription-use-case.ts
@@ -1,15 +1,19 @@
 import { type PrismaClient } from '@prisma/client'
 import { TRPCError } from '@trpc/server'
 import type Stripe from 'stripe'
-import { SubscriptionAccess } from '~/server/api/data-access/subscription-access'
-import { getStripe } from '~/lib/stripe'
+import {
+  SubscriptionAccess,
+  type SubscriptionEventAccess,
+  type SubscriptionEventUser
+} from '~/server/api/data-access/subscription-access'
 import { PRICE_ID_TO_TIER, TIER_TO_PRICE_ID } from '~/lib/stripe-config'
 import { type CreateCheckoutSchema } from '~/schemas/subscription-schema'
 
 export async function createCheckoutSession(
   userId: string,
   input: CreateCheckoutSchema,
-  prisma: PrismaClient
+  prisma: PrismaClient,
+  stripe: Stripe
 ) {
   const access = new SubscriptionAccess(prisma)
   const info = await access.getSubscriptionInfo(userId)
@@ -30,7 +34,7 @@ export async function createCheckoutSession(
       select: { username: true }
     })
 
-    const customer = await getStripe().customers.create({
+    const customer = await stripe.customers.create({
       email: user.username,
       metadata: { userId }
     })
@@ -44,7 +48,7 @@ export async function createCheckoutSession(
     throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid tier' })
   }
 
-  const session = await getStripe().checkout.sessions.create({
+  const session = await stripe.checkout.sessions.create({
     customer: customerId,
     mode: 'subscription',
     line_items: [{ price: priceId, quantity: 1 }],
@@ -57,7 +61,8 @@ export async function createCheckoutSession(
 
 export async function createPortalSession(
   userId: string,
-  prisma: PrismaClient
+  prisma: PrismaClient,
+  stripe: Stripe
 ) {
   const access = new SubscriptionAccess(prisma)
   const info = await access.getSubscriptionInfo(userId)
@@ -69,7 +74,7 @@ export async function createPortalSession(
     })
   }
 
-  const session = await getStripe().billingPortal.sessions.create({
+  const session = await stripe.billingPortal.sessions.create({
     customer: info.stripeCustomerId,
     return_url: `${process.env.NEXTAUTH_URL}/en/subscription`
   })
@@ -85,6 +90,61 @@ export async function getSubscriptionInfo(
   return await access.getSubscriptionInfo(userId)
 }
 
+/** Dependencies the Stripe webhook entry point needs, injected so tests use fakes. */
+export type StripeEventDeps = {
+  stripe: Stripe
+  access: SubscriptionEventAccess
+}
+
+/**
+ * The outcome of handling one Stripe event, made explicit so unknown customers
+ * and unhandled event types are tested no-ops rather than silent fall-through.
+ */
+export type HandleStripeEventResult =
+  | { status: 'updated'; userId: string }
+  | { status: 'ignored'; reason: 'unhandled_event' | 'unknown_customer' }
+
+/**
+ * The one seam that maps a verified Stripe event to a subscription-state change.
+ * The webhook route verifies the signature and delegates here; everything the
+ * money path does — customer resolution, tier resolution, and the write — lives
+ * behind this entry point so it can be driven by fixture events in tests.
+ */
+export async function handleStripeEvent(
+  event: Stripe.Event,
+  deps: StripeEventDeps
+): Promise<HandleStripeEventResult> {
+  const { access } = deps
+
+  switch (event.type) {
+    case 'customer.subscription.created':
+      return applySubscription(
+        event.data.object as Stripe.Subscription,
+        access,
+        'ACTIVE'
+      )
+
+    case 'customer.subscription.updated':
+      return applySubscription(
+        event.data.object as Stripe.Subscription,
+        access,
+        subscriptionStatusFor(event.data.object as Stripe.Subscription)
+      )
+
+    case 'customer.subscription.deleted':
+      return revokeSubscription(
+        event.data.object as Stripe.Subscription,
+        access
+      )
+
+    case 'invoice.payment_failed':
+      return markPaymentFailed(event.data.object as Stripe.Invoice, access)
+
+    default:
+      return { status: 'ignored', reason: 'unhandled_event' }
+  }
+}
+
 function getFirstItem(subscription: Stripe.Subscription) {
   return subscription.items.data[0]
 }
@@ -95,66 +155,49 @@ function resolveTierFromSubscription(subscription: Stripe.Subscription) {
   return PRICE_ID_TO_TIER[priceId] ?? ('FREE' as const)
 }
 
-export async function handleSubscriptionCreated(
-  subscription: Stripe.Subscription,
-  prisma: PrismaClient
-) {
-  const customerId =
-    typeof subscription.customer === 'string'
-      ? subscription.customer
-      : subscription.customer.id
-
-  const access = new SubscriptionAccess(prisma)
-  const user = await access.getUserByStripeCustomerId(customerId)
-  if (!user) return
-
-  const tier = resolveTierFromSubscription(subscription)
+function periodEndFromSubscription(subscription: Stripe.Subscription) {
   const periodEnd = getFirstItem(subscription)?.current_period_end
-  await access.updateSubscription(user.id, {
-    stripeSubscriptionId: subscription.id,
-    subscriptionTier: tier,
-    subscriptionStatus: 'ACTIVE',
-    currentPeriodEnd: periodEnd ? new Date(periodEnd * 1000) : null
-  })
+  return periodEnd ? new Date(periodEnd * 1000) : null
 }
 
-export async function handleSubscriptionUpdated(
-  subscription: Stripe.Subscription,
-  prisma: PrismaClient
-) {
+function subscriptionStatusFor(subscription: Stripe.Subscription) {
+  return subscription.status === 'active' ? 'ACTIVE' : 'INCOMPLETE'
+}
+
+/** The single customer-to-user resolution shared by every event branch. */
+async function resolveUser(
+  customer: string | { id: string } | null | undefined,
+  access: SubscriptionEventAccess
+): Promise<SubscriptionEventUser | null> {
   const customerId =
-    typeof subscription.customer === 'string'
-      ? subscription.customer
-      : subscription.customer.id
+    typeof customer === 'string' ? customer : (customer?.id ?? null)
+  if (!customerId) return null
+  return access.getUserByStripeCustomerId(customerId)
+}
 
-  const access = new SubscriptionAccess(prisma)
-  const user = await access.getUserByStripeCustomerId(customerId)
-  if (!user) return
-
-  const tier = resolveTierFromSubscription(subscription)
-  const status = subscription.status === 'active' ? 'ACTIVE' : 'INCOMPLETE'
-  const periodEnd = getFirstItem(subscription)?.current_period_end
+async function applySubscription(
+  subscription: Stripe.Subscription,
+  access: SubscriptionEventAccess,
+  status: 'ACTIVE' | 'INCOMPLETE'
+): Promise<HandleStripeEventResult> {
+  const user = await resolveUser(subscription.customer, access)
+  if (!user) return { status: 'ignored', reason: 'unknown_customer' }
 
   await access.updateSubscription(user.id, {
     stripeSubscriptionId: subscription.id,
-    subscriptionTier: tier,
+    subscriptionTier: resolveTierFromSubscription(subscription),
     subscriptionStatus: status,
-    currentPeriodEnd: periodEnd ? new Date(periodEnd * 1000) : null
+    currentPeriodEnd: periodEndFromSubscription(subscription)
   })
+  return { status: 'updated', userId: user.id }
 }
 
-export async function handleSubscriptionDeleted(
+async function revokeSubscription(
   subscription: Stripe.Subscription,
-  prisma: PrismaClient
-) {
-  const customerId =
-    typeof subscription.customer === 'string'
-      ? subscription.customer
-      : subscription.customer.id
-
-  const access = new SubscriptionAccess(prisma)
-  const user = await access.getUserByStripeCustomerId(customerId)
-  if (!user) return
+  access: SubscriptionEventAccess
+): Promise<HandleStripeEventResult> {
+  const user = await resolveUser(subscription.customer, access)
+  if (!user) return { status: 'ignored', reason: 'unknown_customer' }
 
   await access.updateSubscription(user.id, {
     stripeSubscriptionId: null,
@@ -162,25 +205,19 @@ export async function handleSubscriptionDeleted(
     subscriptionStatus: 'CANCELED',
     currentPeriodEnd: null
   })
+  return { status: 'updated', userId: user.id }
 }
 
-export async function handlePaymentFailed(
+async function markPaymentFailed(
   invoice: Stripe.Invoice,
-  prisma: PrismaClient
-) {
-  const customerId =
-    typeof invoice.customer === 'string'
-      ? invoice.customer
-      : invoice.customer?.id
-
-  if (!customerId) return
-
-  const access = new SubscriptionAccess(prisma)
-  const user = await access.getUserByStripeCustomerId(customerId)
-  if (!user) return
+  access: SubscriptionEventAccess
+): Promise<HandleStripeEventResult> {
+  const user = await resolveUser(invoice.customer, access)
+  if (!user) return { status: 'ignored', reason: 'unknown_customer' }
 
   await access.updateSubscription(user.id, {
     subscriptionTier: user.subscriptionTier,
     subscriptionStatus: 'PAST_DUE'
   })
+  return { status: 'updated', userId: user.id }
 }


### PR DESCRIPTION
Closes #565

## What & why

The Stripe webhook — the subscription money path that grants, updates, and
revokes a user's Tier — had zero tests because the seam to Stripe was crossed
badly: four separate handlers each re-implemented customer-to-user resolution,
and the Stripe client was constructed inline, so exercising any handler needed a
real client and network.

This PR introduces **one entry point** that owns the event-to-Tier translation
and makes the whole money path testable with fixtures.

- `handleStripeEvent(event, { stripe, access })` on the subscription use-case is
  the single seam. It dispatches internally to per-event behaviour; the four
  formerly-exported handlers are now internal implementation.
- Customer-to-user resolution is written **once** (`resolveUser`), shared by
  every branch.
- Dependencies are **injected, not created**: a `SubscriptionEventAccess`
  data-access port with two adapters — the Prisma-backed `SubscriptionAccess`
  (prod) and an in-memory fake (tests) — plus the Stripe client. Checkout/portal
  session creation now receive the injected client too; behaviour unchanged.
- Unhandled event types and unknown customers return **explicit no-op results**
  (`{ status: 'ignored', reason }`) instead of switch fall-through.
- The webhook route shrinks to signature verification + one delegate call.
- No schema changes; Tier enum and subscription fields untouched.

Maps to acceptance criteria: paid-tier activation (1), plan-change update (2),
cancel downgrade (3), payment-failed status (4), one entry point (5), single
customer resolution (6), injected deps (7), fixture tests per event (8), explicit
no-ops (9), pinned price→Tier table (10), thin route (11), untouched checkout/
portal (12).

## How it's tested

New colocated `subscription-use-case.test.ts` feeds trimmed fixture events
(`subscription-use-case.fixtures.ts`) into `handleStripeEvent` with a fake Stripe
client and a fake access adapter — no DB, no network — and asserts on the
externally visible outcome (the subscription state written), never on internal
dispatch. 11 tests: each handled event's happy path, unknown-customer no-op,
no-customer invoice no-op, unhandled-event no-op, and the price→Tier resolution
table. Full gate green (typecheck, lint, format, 37 test suites).

## Reviewer notes

- The fake-adapter pattern is new to this repo and is intended as the template
  for future ports-and-adapters seams.
- The price→Tier map is env-derived at import time, so the test mocks
  `~/lib/stripe-config` with fixture price ids to pin the resolution rule
  deterministically without any Stripe env — consistent with CI needing only
  fixtures.
- The route itself stays untested (thin IO adapter: signature check + delegate),
  consistent with how the repo treats other IO adapters.
- Backend-only; not UI-verifiable, so no e2e spec/screenshots were added
  (verified via the integration suite).
