### PR TITLE
Trajectory checks over the agent transcript; stop the local rehearsal discarding it

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -275,6 +275,20 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: bun agent/implement/post-verify.ts
 
+      - name: Post trajectory scorecard to the PR
+        # Observability (#566): grade the run's own trajectory over the captured
+        # transcript and post the scorecard as a PR comment, alongside the verify
+        # report. Deterministic and advisory — findings never fail the run, and
+        # the runner swallows its own errors, so a malformed/missing transcript
+        # degrades to "no scorecard", never a red build. Runs once the draft PR
+        # exists so there is a PR to comment on.
+        if: steps.open_pr.outcome == 'success'
+        continue-on-error: true
+        env:
+          PR_NUMBER: ${{ steps.open_pr.outputs.number }}
+          OUTPUT_DIR: ${{ runner.temp }}
+        run: bun agent/implement/run-trajectory-check.ts
+
       - name: Strip verify screenshots off the branch tip
         # The PR comment's images are pinned to the push commit SHA above, so
         # they keep rendering even after this follow-up commit removes the

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ next-env.d.ts
 /blob-report/
 /playwright/.cache/
 /e2e/.auth/
+
+# agent:local rehearsal outputs preserved on the host (#566) — transcript,
+# reports, and scorecard per run; inspection-only, never committed.
+/.agent/local/runs/

--- a/agent/implement/run-trajectory-check.ts
+++ b/agent/implement/run-trajectory-check.ts
@@ -1,0 +1,84 @@
+import { execFileSync } from 'node:child_process'
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+import { MAX_TURNS } from './run-policy'
+import {
+  checkTrajectory,
+  formatScorecard,
+  type TranscriptEvent
+} from './trajectory-checker'
+
+/**
+ * Thin runner for the deterministic trajectory checker (#566). Reads the
+ * captured Claude Code session transcript, feeds the parsed events into the pure
+ * {@link checkTrajectory} module, and surfaces the scorecard: locally it prints
+ * alongside the other end-of-run reports (entrypoint.sh cats it), and in CI —
+ * when a PR number is present — it posts the scorecard as a PR comment, the same
+ * pattern as the verify-comment flow (post-verify.ts).
+ *
+ * Never-throw by contract (user stories 8/11): findings are advisory and never
+ * change the exit code, and a malformed/missing transcript degrades to "no
+ * scorecard", never a red build. All IO lives here so the checker stays pure.
+ */
+
+const OUTPUT_DIR = process.env.OUTPUT_DIR ?? os.tmpdir()
+const TRANSCRIPT_FILE =
+  process.env.TRANSCRIPT_FILE ?? path.join(OUTPUT_DIR, 'transcript.jsonl')
+const SCORECARD_FILE = path.join(OUTPUT_DIR, 'trajectory_scorecard.md')
+
+/** CI-only: set by the workflow once the draft PR exists. */
+const PR_NUMBER = process.env.PR_NUMBER
+const REPO = process.env.GITHUB_REPOSITORY
+
+try {
+  const scorecard = buildScorecard(TRANSCRIPT_FILE)
+  if (scorecard === null) {
+    console.warn(
+      `No trajectory scorecard: transcript missing or unreadable at ${TRANSCRIPT_FILE}.`
+    )
+  } else {
+    fs.writeFileSync(SCORECARD_FILE, `${scorecard}\n`)
+    console.log(`\n${scorecard}\n`)
+    if (PR_NUMBER && REPO) postComment(PR_NUMBER, REPO, SCORECARD_FILE)
+  }
+} catch (error) {
+  // Observability must never break the run — swallow and warn only.
+  console.warn(`Trajectory check skipped: ${String(error)}`)
+}
+
+/** Parse the JSONL transcript (skipping malformed lines) and render markdown, or null when there is nothing to read. */
+function buildScorecard(file: string): string | null {
+  if (!fs.existsSync(file)) return null
+  const events = readTranscript(file)
+  const findings = checkTrajectory(events, { maxTurns: MAX_TURNS })
+  return formatScorecard(findings)
+}
+
+/** One parsed record per line; a line that fails to parse is dropped, not fatal. */
+function readTranscript(file: string): TranscriptEvent[] {
+  const events: TranscriptEvent[] = []
+  for (const line of fs.readFileSync(file, 'utf8').split('\n')) {
+    if (!line.trim()) continue
+    try {
+      events.push(JSON.parse(line))
+    } catch {
+      // A truncated final line or a stray non-JSON line degrades the transcript
+      // to "partial", never to a throw — checkTrajectory handles a thin result.
+    }
+  }
+  return events
+}
+
+function postComment(prNumber: string, repo: string, bodyFile: string) {
+  try {
+    execFileSync(
+      'gh',
+      ['pr', 'comment', prNumber, '--repo', repo, '--body-file', bodyFile],
+      { stdio: 'inherit' }
+    )
+    console.log(`Posted trajectory scorecard to PR #${prNumber}.`)
+  } catch (error) {
+    console.warn(`Could not post trajectory scorecard: ${String(error)}`)
+  }
+}

--- a/agent/implement/trajectory-checker.test.ts
+++ b/agent/implement/trajectory-checker.test.ts
@@ -1,0 +1,298 @@
+/**
+ * @jest-environment node
+ */
+import {
+  checkTrajectory,
+  formatScorecard,
+  INVARIANTS,
+  DEFAULT_HEADROOM_FRACTION,
+  type TranscriptEvent,
+  type TrajectoryFinding,
+  type TrajectoryInvariantId,
+  type TrajectoryStatus
+} from './trajectory-checker'
+
+// --- Fixture builders: parsed transcript events, checked in beside the test ---
+// Each helper emits the same shape the Claude Code session JSONL records use, so
+// a fixture transcript is just an ordered array of these — clean trajectories
+// and one-violation-each trajectories, pinning every invariant in both
+// directions (per #566 testing decisions).
+
+let nextTurn = 0
+
+/** One assistant turn issuing a Bash command; returns the tool_use id. */
+function bash(command: string): { events: TranscriptEvent[]; id: string } {
+  nextTurn += 1
+  const id = `tool_${nextTurn}`
+  return {
+    id,
+    events: [
+      {
+        type: 'assistant',
+        message: {
+          id: `msg_${nextTurn}`,
+          content: [{ type: 'tool_use', id, name: 'Bash', input: { command } }]
+        }
+      }
+    ]
+  }
+}
+
+/** The user tool_result pairing a Bash call with a pass/fail exit. */
+function result(id: string, failed: boolean): TranscriptEvent {
+  return {
+    type: 'user',
+    message: {
+      content: [{ type: 'tool_result', tool_use_id: id, is_error: failed }]
+    }
+  }
+}
+
+/** A completed shell step: the assistant turn plus its (passing) result. */
+function step(command: string): TranscriptEvent[] {
+  const { events, id } = bash(command)
+  return [...events, result(id, false)]
+}
+
+/** A shell step whose command failed (non-zero exit). */
+function failingStep(command: string): TranscriptEvent[] {
+  const { events, id } = bash(command)
+  return [...events, result(id, true)]
+}
+
+const OPTIONS = { maxTurns: 150 }
+
+beforeEach(() => {
+  nextTurn = 0
+})
+
+function find(
+  findings: TrajectoryFinding[],
+  id: TrajectoryInvariantId
+): TrajectoryFinding {
+  const finding = findings.find((f) => f.id === id)
+  if (!finding) throw new Error(`no finding for ${id}`)
+  return finding
+}
+
+function statuses(
+  findings: TrajectoryFinding[]
+): Record<TrajectoryInvariantId, TrajectoryStatus> {
+  return Object.fromEntries(findings.map((f) => [f.id, f.status])) as Record<
+    TrajectoryInvariantId,
+    TrajectoryStatus
+  >
+}
+
+/** A clean trajectory: RED (failing test) → GREEN → gate → commit, no bad ops. */
+function cleanTrajectory(): TranscriptEvent[] {
+  return [
+    ...failingStep('bun run test agent/implement/trajectory-checker.test.ts'),
+    ...step('bun run typecheck'),
+    ...step('bun run lint'),
+    ...step('bun run format'),
+    ...step('bun run test'),
+    ...step('git add -A && git commit -m "feat: add trajectory checker"')
+  ]
+}
+
+describe('checkTrajectory', () => {
+  it('passes every invariant on a clean trajectory', () => {
+    const findings = checkTrajectory(cleanTrajectory(), OPTIONS)
+    expect(findings.map((f) => f.id)).toEqual(INVARIANTS.map((i) => i.id))
+    for (const finding of findings) {
+      expect(finding.status).toBe('pass')
+    }
+  })
+
+  describe('gate-before-commit', () => {
+    it('fails when a commit is not preceded by a gate run', () => {
+      const events = [
+        ...step('git add -A && git commit -m "chore: commit without gate"')
+      ]
+      const finding = find(
+        checkTrajectory(events, OPTIONS),
+        'gate-before-commit'
+      )
+      expect(finding.status).toBe('fail')
+      expect(finding.evidence).toHaveLength(1)
+      expect(finding.evidence[0].command).toContain('git commit')
+    })
+
+    it('requires the gate again for a second commit', () => {
+      const events = [
+        ...step('bun run test'),
+        ...step('git commit -m "feat: first"'),
+        // no gate rerun before the second commit
+        ...step('git commit -m "feat: second"')
+      ]
+      const finding = find(
+        checkTrajectory(events, OPTIONS),
+        'gate-before-commit'
+      )
+      expect(finding.status).toBe('fail')
+      expect(finding.evidence).toHaveLength(1)
+      expect(finding.evidence[0].command).toContain('second')
+    })
+
+    it('passes vacuously when the run made no commits', () => {
+      const events = [...step('bun run test')]
+      const finding = find(
+        checkTrajectory(events, OPTIONS),
+        'gate-before-commit'
+      )
+      expect(finding.status).toBe('pass')
+      expect(finding.detail).toMatch(/no commits/)
+    })
+  })
+
+  describe('red-before-green', () => {
+    it('fails when no failing test preceded the first commit', () => {
+      const events = [
+        ...step('bun run test'), // passing only — never saw RED
+        ...step('git commit -m "feat: no red"')
+      ]
+      const finding = find(checkTrajectory(events, OPTIONS), 'red-before-green')
+      expect(finding.status).toBe('fail')
+    })
+
+    it('passes when a failing test preceded the first commit', () => {
+      const finding = find(
+        checkTrajectory(cleanTrajectory(), OPTIONS),
+        'red-before-green'
+      )
+      expect(finding.status).toBe('pass')
+    })
+
+    it('is not-evaluable when there is no commit', () => {
+      const events = [...failingStep('bun run test')]
+      const finding = find(checkTrajectory(events, OPTIONS), 'red-before-green')
+      expect(finding.status).toBe('not-evaluable')
+    })
+  })
+
+  describe('no-forbidden-git-ops', () => {
+    it('flags a force-push', () => {
+      const events = [...step('git push --force origin my-branch')]
+      const finding = find(
+        checkTrajectory(events, OPTIONS),
+        'no-forbidden-git-ops'
+      )
+      expect(finding.status).toBe('fail')
+      expect(finding.detail).toContain('force')
+    })
+
+    it('flags a -f force-push shorthand', () => {
+      const events = [...step('git push -f origin my-branch')]
+      const finding = find(
+        checkTrajectory(events, OPTIONS),
+        'no-forbidden-git-ops'
+      )
+      expect(finding.status).toBe('fail')
+    })
+
+    it('flags a commit --amend', () => {
+      const events = [...step('git commit --amend -m "rewrite history"')]
+      const finding = find(
+        checkTrajectory(events, OPTIONS),
+        'no-forbidden-git-ops'
+      )
+      expect(finding.status).toBe('fail')
+      expect(finding.detail).toContain('amend')
+    })
+
+    it('passes on an ordinary push', () => {
+      const events = [...step('git push -u origin my-branch')]
+      const finding = find(
+        checkTrajectory(events, OPTIONS),
+        'no-forbidden-git-ops'
+      )
+      expect(finding.status).toBe('pass')
+    })
+  })
+
+  describe('turn-budget-headroom', () => {
+    it('passes with ample headroom', () => {
+      const finding = find(
+        checkTrajectory(cleanTrajectory(), { maxTurns: 150 }),
+        'turn-budget-headroom'
+      )
+      expect(finding.status).toBe('pass')
+      expect(finding.detail).toContain('/150 turns')
+    })
+
+    it('fails when turns reach the headroom threshold', () => {
+      // 5 turns against a cap of 5 → 100% used, no headroom.
+      const events = [
+        ...step('a'),
+        ...step('b'),
+        ...step('c'),
+        ...step('d'),
+        ...step('e')
+      ]
+      const finding = find(
+        checkTrajectory(events, {
+          maxTurns: 5,
+          headroomFraction: DEFAULT_HEADROOM_FRACTION
+        }),
+        'turn-budget-headroom'
+      )
+      expect(finding.status).toBe('fail')
+    })
+  })
+
+  describe('not-evaluable transcripts', () => {
+    it('grades every invariant not-evaluable for an empty transcript', () => {
+      const findings = checkTrajectory([], OPTIONS)
+      for (const finding of findings) {
+        expect(finding.status).toBe('not-evaluable')
+      }
+    })
+
+    it('grades every invariant not-evaluable for a truncated/malformed transcript', () => {
+      // A record with no assistant turn — e.g. a transcript cut off mid-write.
+      const findings = checkTrajectory(
+        [{ type: 'summary', summary: 'truncated' }],
+        OPTIONS
+      )
+      expect(statuses(findings)).toEqual({
+        'gate-before-commit': 'not-evaluable',
+        'red-before-green': 'not-evaluable',
+        'no-forbidden-git-ops': 'not-evaluable',
+        'turn-budget-headroom': 'not-evaluable'
+      })
+    })
+
+    it('does not throw on a non-array input', () => {
+      expect(() =>
+        checkTrajectory(null as unknown as TranscriptEvent[], OPTIONS)
+      ).not.toThrow()
+    })
+  })
+})
+
+describe('formatScorecard', () => {
+  it('renders a terse table with one row per invariant', () => {
+    const markdown = formatScorecard(
+      checkTrajectory(cleanTrajectory(), OPTIONS)
+    )
+    expect(markdown).toContain('Trajectory scorecard')
+    expect(markdown).toContain('| Invariant | Result |')
+    expect(markdown).toContain('4/4 process invariants passed')
+    for (const invariant of INVARIANTS) {
+      expect(markdown).toContain(invariant.title)
+    }
+  })
+
+  it('lists evidence turns for anything that did not pass', () => {
+    const events = [...step('git add -A && git commit -m "chore: no gate"')]
+    const markdown = formatScorecard(checkTrajectory(events, OPTIONS))
+    expect(markdown).toContain('❌ fail')
+    expect(markdown).toMatch(/turn \d+/)
+  })
+
+  it('is a pure function of its findings', () => {
+    const findings = checkTrajectory(cleanTrajectory(), OPTIONS)
+    expect(formatScorecard(findings)).toBe(formatScorecard(findings))
+  })
+})

--- a/agent/implement/trajectory-checker.ts
+++ b/agent/implement/trajectory-checker.ts
@@ -1,0 +1,406 @@
+/**
+ * Deterministic trajectory checker for the `agent:implement` pipeline (#566).
+ *
+ * A pure module — parsed transcript events in, findings out — that grades *how*
+ * an agent run worked, not just what it produced. The agent's Claude Code
+ * session transcript records every tool call it made; this module asserts
+ * process invariants over that record (the quality gate ran before each commit,
+ * a failing test preceded the first commit, no force-push/amend, turn-budget
+ * headroom) so process failures become visible even when the output happens to
+ * pass. No IO here: reading and parsing the transcript file stays in the thin
+ * runner (run-trajectory-check.ts) so this stays testable with fixtures.
+ *
+ * The invariant set is a plain data structure ({@link INVARIANTS}) — adding an
+ * invariant is one entry plus fixtures. Findings are advisory by contract: the
+ * runner never changes the run's exit code over them (#566, user stories 8/11).
+ */
+
+/** A single parsed record from the Claude Code session transcript (JSONL). */
+export type TranscriptEvent = Record<string, unknown>
+
+export type TrajectoryStatus = 'pass' | 'fail' | 'not-evaluable'
+
+/** Stable ids — a month of scorecards clusters on these, so they never churn. */
+export type TrajectoryInvariantId =
+  | 'gate-before-commit'
+  | 'red-before-green'
+  | 'no-forbidden-git-ops'
+  | 'turn-budget-headroom'
+
+/** The offending turn (and command) that produced a fail — the evidence. */
+export interface TrajectoryEvidence {
+  /** 1-based index of the transcript turn the offending tool call belongs to. */
+  turnIndex: number
+  /** The offending shell command, when the evidence is a Bash call. */
+  command?: string
+}
+
+export interface TrajectoryFinding {
+  id: TrajectoryInvariantId
+  title: string
+  status: TrajectoryStatus
+  /** Terse human-readable evidence line. */
+  detail: string
+  evidence: TrajectoryEvidence[]
+}
+
+export interface CheckTrajectoryOptions {
+  /** The run-policy max-turns cap the budget headroom is measured against. */
+  maxTurns: number
+  /**
+   * Fraction of the cap that must remain unused for the budget invariant to
+   * pass. Default 0.2 — a run using ≥80% of its turns barely fit and is
+   * flagged before it starts failing.
+   */
+  headroomFraction?: number
+}
+
+/** Default headroom: flag a run that used ≥80% of its turn cap. */
+export const DEFAULT_HEADROOM_FRACTION = 0.2
+
+// --- Command classification (deterministic, regex over the Bash command) ------
+
+/**
+ * The quality gate's culminating step (`bun run test`, which expands to
+ * `bunx jest`). Its presence is the proxy for "the gate ran": it is the final
+ * and most expensive gate step, so reaching it means the agent ran the gate.
+ * The `(?![:\w-])` guard excludes `test:e2e` / `test:unit` (verify + partial
+ * scripts), matching only the whole-suite gate run or a `bun run test <path>`.
+ */
+function isGateRun(command: string): boolean {
+  return (
+    /\bbun\s+run\s+test(?![:\w-])/.test(command) ||
+    /\bbun\s+test(?![:\w-])/.test(command) ||
+    /\bbunx?\s+jest\b/.test(command)
+  )
+}
+
+/** A `git commit` (any form, including `--amend`). */
+function isCommit(command: string): boolean {
+  return /\bgit\s+commit\b/.test(command)
+}
+
+/**
+ * A forbidden history rewrite: force-push or amend. Detection only — the
+ * complementary preventive hooks are out of scope for #566.
+ */
+function forbiddenGitOp(command: string): string | null {
+  if (/\bgit\s+commit\b[^\n]*--amend\b/.test(command))
+    return 'git commit --amend'
+  if (
+    /\bgit\s+push\b/.test(command) &&
+    /(--force-with-lease\b|--force\b|(^|\s)-f(\s|$))/.test(command)
+  ) {
+    return 'git push --force'
+  }
+  return null
+}
+
+// --- Normalization ------------------------------------------------------------
+
+interface Action {
+  turnIndex: number
+  tool: string
+  command: string | null
+  toolUseId: string | null
+  /** From the paired tool_result's is_error; null when unknown/unpaired. */
+  failed: boolean | null
+}
+
+interface NormalizedTrajectory {
+  actions: Action[]
+  turnCount: number
+  /** False for an empty / truncated / malformed transcript with no turns. */
+  evaluable: boolean
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function contentBlocks(
+  event: Record<string, unknown>
+): Record<string, unknown>[] {
+  const message = asRecord(event.message)
+  const content = message?.content
+  if (!Array.isArray(content)) return []
+  return content
+    .map(asRecord)
+    .filter((b): b is Record<string, unknown> => b !== null)
+}
+
+/**
+ * Fold the raw transcript into an ordered action list with turn indices and
+ * pass/fail results, pairing each tool_use with its tool_result via id. Never
+ * throws on odd shapes — an unrecognizable record contributes nothing.
+ */
+function normalize(events: unknown): NormalizedTrajectory {
+  if (!Array.isArray(events)) {
+    return { actions: [], turnCount: 0, evaluable: false }
+  }
+
+  const resultErrors = new Map<string, boolean>()
+  const rawActions: Action[] = []
+  let turnCount = 0
+  let lastAssistantId: unknown = Symbol('none')
+
+  for (const raw of events) {
+    const event = asRecord(raw)
+    if (!event) continue
+
+    if (event.type === 'assistant') {
+      const message = asRecord(event.message)
+      const id = message?.id
+      // A new turn whenever the assistant message id changes (or is absent).
+      if (id === undefined || id === null || id !== lastAssistantId) turnCount++
+      lastAssistantId = id
+      for (const block of contentBlocks(event)) {
+        if (block.type !== 'tool_use') continue
+        const input = asRecord(block.input) ?? {}
+        const command = typeof input.command === 'string' ? input.command : null
+        rawActions.push({
+          turnIndex: turnCount,
+          tool: typeof block.name === 'string' ? block.name : 'unknown',
+          command,
+          toolUseId: typeof block.id === 'string' ? block.id : null,
+          failed: null
+        })
+      }
+    } else if (event.type === 'user') {
+      for (const block of contentBlocks(event)) {
+        if (block.type !== 'tool_result') continue
+        const id = block.tool_use_id
+        if (typeof id === 'string' && typeof block.is_error === 'boolean') {
+          resultErrors.set(id, block.is_error)
+        }
+      }
+    }
+  }
+
+  for (const action of rawActions) {
+    if (action.toolUseId !== null && resultErrors.has(action.toolUseId)) {
+      action.failed = resultErrors.get(action.toolUseId) ?? null
+    }
+  }
+
+  return { actions: rawActions, turnCount, evaluable: turnCount > 0 }
+}
+
+// --- Invariants (plain data — add one entry + fixtures to extend) -------------
+
+interface InvariantContext {
+  actions: Action[]
+  turnCount: number
+  options: CheckTrajectoryOptions
+}
+
+interface InvariantResult {
+  status: TrajectoryStatus
+  detail: string
+  evidence: TrajectoryEvidence[]
+}
+
+interface InvariantDefinition {
+  id: TrajectoryInvariantId
+  title: string
+  evaluate(ctx: InvariantContext): InvariantResult
+}
+
+export const INVARIANTS: InvariantDefinition[] = [
+  {
+    id: 'gate-before-commit',
+    title: 'Quality gate ran before every commit',
+    evaluate({ actions }) {
+      let gateRan = false
+      let commitCount = 0
+      const offenders: TrajectoryEvidence[] = []
+      for (const action of actions) {
+        if (action.command === null) continue
+        if (isGateRun(action.command)) gateRan = true
+        if (isCommit(action.command)) {
+          commitCount++
+          if (!gateRan) {
+            offenders.push({
+              turnIndex: action.turnIndex,
+              command: action.command
+            })
+          }
+          gateRan = false
+        }
+      }
+      if (offenders.length > 0) {
+        return {
+          status: 'fail',
+          detail: `${offenders.length} of ${commitCount} commit(s) not preceded by a gate run`,
+          evidence: offenders
+        }
+      }
+      return {
+        status: 'pass',
+        detail:
+          commitCount === 0
+            ? 'no commits in this run'
+            : `gate ran before each of ${commitCount} commit(s)`,
+        evidence: []
+      }
+    }
+  },
+  {
+    id: 'red-before-green',
+    title: 'A failing test preceded the first commit (RED before GREEN)',
+    evaluate({ actions }) {
+      const firstCommit = actions.findIndex(
+        (a) => a.command !== null && isCommit(a.command)
+      )
+      if (firstCommit === -1) {
+        return {
+          status: 'not-evaluable',
+          detail: 'no implementation commit to evaluate',
+          evidence: []
+        }
+      }
+      const sawFailingTest = actions
+        .slice(0, firstCommit)
+        .some(
+          (a) => a.command !== null && isGateRun(a.command) && a.failed === true
+        )
+      if (sawFailingTest) {
+        return {
+          status: 'pass',
+          detail: 'a failing test run preceded the first commit',
+          evidence: []
+        }
+      }
+      const commit = actions[firstCommit]
+      return {
+        status: 'fail',
+        detail: 'no failing test run observed before the first commit',
+        evidence: [
+          { turnIndex: commit.turnIndex, command: commit.command ?? undefined }
+        ]
+      }
+    }
+  },
+  {
+    id: 'no-forbidden-git-ops',
+    title: 'No force-push or amend in the trajectory',
+    evaluate({ actions }) {
+      const offenders: TrajectoryEvidence[] = []
+      const kinds = new Set<string>()
+      for (const action of actions) {
+        if (action.command === null) continue
+        const op = forbiddenGitOp(action.command)
+        if (op !== null) {
+          kinds.add(op)
+          offenders.push({
+            turnIndex: action.turnIndex,
+            command: action.command
+          })
+        }
+      }
+      if (offenders.length > 0) {
+        return {
+          status: 'fail',
+          detail: `forbidden git op(s): ${[...kinds].join(', ')}`,
+          evidence: offenders
+        }
+      }
+      return { status: 'pass', detail: 'no force-push or amend', evidence: [] }
+    }
+  },
+  {
+    id: 'turn-budget-headroom',
+    title: 'Turn usage within headroom of the cap',
+    evaluate({ turnCount, options }) {
+      const headroom = options.headroomFraction ?? DEFAULT_HEADROOM_FRACTION
+      const threshold = Math.ceil(options.maxTurns * (1 - headroom))
+      const detail = `${turnCount}/${options.maxTurns} turns used`
+      if (turnCount >= threshold) {
+        return {
+          status: 'fail',
+          detail: `${detail} (≥${threshold} — under ${Math.round(headroom * 100)}% headroom)`,
+          evidence: []
+        }
+      }
+      return { status: 'pass', detail, evidence: [] }
+    }
+  }
+]
+
+/**
+ * Grade a parsed transcript against every process invariant. Pure: same events
+ * in, same findings out. An empty / truncated / malformed transcript (no
+ * assistant turns) grades every invariant `not-evaluable` rather than throwing.
+ */
+export function checkTrajectory(
+  events: TranscriptEvent[] | unknown,
+  options: CheckTrajectoryOptions
+): TrajectoryFinding[] {
+  const { actions, turnCount, evaluable } = normalize(events)
+  if (!evaluable) {
+    return INVARIANTS.map((invariant) => ({
+      id: invariant.id,
+      title: invariant.title,
+      status: 'not-evaluable' as const,
+      detail: 'transcript not evaluable (empty, truncated, or malformed)',
+      evidence: []
+    }))
+  }
+  const ctx: InvariantContext = { actions, turnCount, options }
+  return INVARIANTS.map((invariant) => {
+    const result = invariant.evaluate(ctx)
+    return {
+      id: invariant.id,
+      title: invariant.title,
+      status: result.status,
+      detail: result.detail,
+      evidence: result.evidence
+    }
+  })
+}
+
+// --- Scorecard formatting (pure: findings in, markdown out) --------------------
+
+const STATUS_MARK: Record<TrajectoryStatus, string> = {
+  pass: '✅ pass',
+  fail: '❌ fail',
+  'not-evaluable': '⚪ n/a'
+}
+
+/**
+ * Render findings as a terse, stable markdown scorecard: a summary line, a
+ * one-row-per-invariant table, then an evidence block for anything that did not
+ * pass. Terse on purpose — scanning a month of PRs surfaces clustered process
+ * failures at a glance.
+ */
+export function formatScorecard(findings: TrajectoryFinding[]): string {
+  const passes = findings.filter((f) => f.status === 'pass').length
+  const lines: string[] = []
+  lines.push('### 🧭 Trajectory scorecard')
+  lines.push('')
+  lines.push(
+    `${passes}/${findings.length} process invariants passed _(advisory — never blocks the PR)_.`
+  )
+  lines.push('')
+  lines.push('| Invariant | Result |')
+  lines.push('| --- | --- |')
+  for (const finding of findings) {
+    lines.push(`| ${finding.title} | ${STATUS_MARK[finding.status]} |`)
+  }
+
+  const notable = findings.filter((f) => f.status !== 'pass')
+  if (notable.length > 0) {
+    lines.push('')
+    for (const finding of notable) {
+      const turns = finding.evidence
+        .map((e) => `turn ${e.turnIndex}`)
+        .join(', ')
+      const where = turns.length > 0 ? ` (${turns})` : ''
+      lines.push(`- **${finding.title}** — ${finding.detail}${where}`)
+    }
+  }
+
+  return lines.join('\n')
+}

--- a/agent/local/docker-compose.yml
+++ b/agent/local/docker-compose.yml
@@ -51,3 +51,9 @@ services:
         source: ${STANDARDS_HOST_DIR:?Set STANDARDS_HOST_DIR}
         target: /standards
         read_only: true
+      # The agent's output dir (#566): transcript, PR description, verify report,
+      # and trajectory scorecard. Bind-mounted to a host dir so they survive the
+      # container instead of vanishing when it is removed.
+      - type: bind
+        source: ${HOST_OUTPUT_DIR:?Set HOST_OUTPUT_DIR}
+        target: /workdir/output

--- a/agent/local/entrypoint.sh
+++ b/agent/local/entrypoint.sh
@@ -102,6 +102,12 @@ if [ -f "${OUTPUT_DIR}/verify_report.md" ]; then
   cat "${OUTPUT_DIR}/verify_report.md"
 fi
 
+# Grade the run's trajectory over the captured transcript (#566). Deterministic,
+# advisory, never-throw — a missing/malformed transcript just prints no
+# scorecard. No PR_NUMBER locally, so it prints rather than posting a comment.
+echo "==> Trajectory scorecard:"
+OUTPUT_DIR="$OUTPUT_DIR" bun agent/implement/run-trajectory-check.ts || true
+
 if [ "$AGENT_EXIT_CODE" -ne 0 ] && [ -f "${OUTPUT_DIR}/failure_reason.txt" ]; then
   echo "==> Failure reason:"
   cat "${OUTPUT_DIR}/failure_reason.txt"

--- a/agent/local/run.sh
+++ b/agent/local/run.sh
@@ -43,6 +43,14 @@ OPENAI_API_KEY="$(env_fallback OPENAI_API_KEY)"
 
 HOST_GIT_DIR="$(git -C "$REPO_ROOT" rev-parse --absolute-git-dir)"
 
+# Preserve the container's output dir on the host (#566): the transcript, PR
+# description, verify report, and trajectory scorecard are written under
+# /workdir/output inside the container and vanish with it. Bind-mounting a
+# host dir keeps every run's outputs for inspection. Timestamped so runs never
+# clobber each other; gitignored so they never pollute `git status`.
+HOST_OUTPUT_DIR="$REPO_ROOT/.agent/local/runs/$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$HOST_OUTPUT_DIR"
+
 # Mount the maintainer's local skills rules if present; otherwise mount an
 # empty scratch dir so entrypoint.sh's "non-empty directory" check correctly
 # skips the standards step (docs/agents/domain.md / memory: skills live at
@@ -55,7 +63,7 @@ else
 fi
 
 export ISSUE_NUMBER GH_TOKEN CLAUDE_CODE_OAUTH_TOKEN NEXTAUTH_SECRET OPENAI_API_KEY
-export HOST_GIT_DIR STANDARDS_HOST_DIR
+export HOST_GIT_DIR STANDARDS_HOST_DIR HOST_OUTPUT_DIR
 
 cleanup() {
   echo "==> Tearing down the ephemeral pgvector service"
@@ -65,3 +73,6 @@ trap cleanup EXIT
 
 echo "==> Starting agent:local for issue #${ISSUE_NUMBER}"
 docker compose -f "$COMPOSE_FILE" run --rm --build agent
+
+echo "==> Run outputs preserved on the host at: ${HOST_OUTPUT_DIR}"
+echo "    (transcript.jsonl, pr_description.txt, verify_report.md, trajectory_scorecard.md)"


### PR DESCRIPTION
Closes #566

## What & why

Closes the observability loop for the `agent:implement` pipeline (#566). Until
now the pipeline recorded what an agent *produced* but nothing graded *how* it
worked, and the local Docker rehearsal — the cheapest place to study agent
behaviour — threw its transcript away when the container was removed.

This PR adds:

- **A pure trajectory checker** (`agent/implement/trajectory-checker.ts`) —
  parsed transcript events in, findings out, no IO. It asserts four process
  invariants, defined as a plain data structure (`INVARIANTS`) so adding one is
  one entry plus fixtures:
  1. `gate-before-commit` — the quality gate (`bun run test`) ran before every
     `git commit`;
  2. `red-before-green` — a *failing* test run preceded the first commit (TDD);
  3. `no-forbidden-git-ops` — no force-push (`--force`/`--force-with-lease`/`-f`)
     or `commit --amend`;
  4. `turn-budget-headroom` — turn usage stayed under an 80% headroom of the
     run-policy max-turns cap.
  Plus `formatScorecard`, a pure findings→markdown terse scorecard.
- **A thin never-throw runner** (`agent/implement/run-trajectory-check.ts`) that
  reads the captured transcript (skipping malformed lines), runs the checker,
  writes/prints the scorecard, and — when a PR number is present (CI) — posts it
  as a PR comment, mirroring the verify-comment flow. Observability never breaks
  the run: a missing/malformed transcript degrades to "no scorecard", never a
  red build, and findings never change the exit code.
- **CI wiring** — a `continue-on-error` workflow step posts the scorecard on the
  PR alongside the verify report.
- **Local rehearsal infra fix** — the container's `/workdir/output` is now
  bind-mounted to a timestamped host dir (`.agent/local/runs/<ts>`, gitignored),
  so the transcript, PR description, reports, and scorecard survive the
  container; the entrypoint prints the scorecard with the other end-of-run
  reports.

Advisory-only by design (user stories 8/11): the checks are young, so a process
wobble is reported, never blocking.

## How it's tested

- `agent/implement/trajectory-checker.test.ts` (19 cases): a clean trajectory
  passes all invariants; one fixture per invariant violates exactly that
  invariant in both directions; empty/truncated/malformed transcripts grade
  `not-evaluable` rather than throwing; the scorecard formatter is tested as a
  pure function. Fixtures are arrays of parsed events built beside the test.
- Runner verified by running against a real transcript, a missing transcript,
  and a malformed transcript — all exit 0 with the expected output.
- Full gate green: typecheck, lint, format, `bun run test` (39 suites, 266
  tests).

## Reviewer notes / trade-offs

- The gate detector uses `bun run test` (the gate's final, most expensive step)
  as the proxy for "the gate ran"; `test:e2e`/`test:unit` are deliberately
  excluded via a lookahead so a verify/e2e run isn't mistaken for the gate.
- "Turn" is counted as a distinct assistant message id — a close proxy for the
  CLI's `--max-turns`, documented in the module.
- Detection only, not prevention: deterministic hooks that *block* forbidden git
  ops are complementary future work (candidate #8), out of scope here. An
  LM-as-judge layer would reuse this same checker interface and fixtures.
- Not UI-verifiable — verified via the unit/integration suite and by running the
  runner script; no e2e spec added.
