### PR TITLE
Closes #590 implement RSC data fetching and client cache seeding

### DIFF
--- a/docs/adr/0001-rsc-fetch-and-seed-instead-of-prefetch-hydrate.md
+++ b/docs/adr/0001-rsc-fetch-and-seed-instead-of-prefetch-hydrate.md
@@ -1,0 +1,28 @@
+# ADR 0001 — Pages fetch in the RSC and seed the client cache; no `prefetch`/`HydrateClient`
+
+Date: 2026-08-10
+Status: Accepted
+Issues: #545, #590 (and 781d64b, the `<Suspense>` band-aid)
+
+## Context
+
+Every authenticated page used tRPC's `createHydrationHelpers`: `await api.x.prefetch(...)` in the server component, wrapped in `<HydrateClient>`, with client components reading through `useSuspenseQuery`.
+
+Unlike `useQuery`, `useSuspenseQuery` runs during the **server-render pass** of a client component. The hydration state does not warm the client cache in time for that pass, so it misses and issues a real HTTP request to `/api/trpc`. Server-side there is no browser to attach a cookie, and the client link (`src/trpc/react.tsx`) forwards none, so `protectedProcedure` answers `UNAUTHORIZED`.
+
+The symptom is a runtime error overlay on page load. A `<Suspense>` boundary swallows the suspension but not the throw, so it looks like a routing/boundary problem and gets "fixed" by adding boundaries — which leaves the unauthenticated round trip on every load. We hit this on `/recipes/[slug]` (#545), then `/lists` (#590), and papered over a third instance with a boundary.
+
+## Decision
+
+1. **Pages fetch their data in the RSC**, where the session is available: `const list = await api.lists.byUserId({ userId })`.
+2. **A colocated `*InitialDataProvider` client component seeds the query cache during render**, via `useSeedQueryCache` (`src/hooks/use-seed-query-cache.ts`), which runs the seed in a `useState` initializer — before children mount, on both passes.
+3. **Seeding uses `utils.x.setData(...)`, not per-hook `initialData`.** React Query ignores `initialData` once the query already exists in the cache (e.g. a cache-only reader ran first).
+4. **`src/trpc/server.ts` exports a plain `createCaller`, not `createHydrationHelpers`.** There is no `prefetch` and no `HydrateClient` to reach for — the pattern is banned at the type level rather than by convention or a lint rule.
+5. **A dev-only link makes a violation loud**: `createServerRenderGuardLink` refuses any request issued during the server-render pass with a named `ServerRenderQueryError` that says what to do, instead of letting it come back as `UNAUTHORIZED`.
+
+## Consequences
+
+- Seed inputs must match the client query key exactly. `/recipes` had been prefetching `limit: 10` while the client asked for `limit: 12`, so the prefetch had never once been used; the constant now lives in `src/app/recipes/recipes-constants.ts` and both sides import it.
+- A page that adds a new suspense-read query must extend that page's provider, or the query fetches on the client (in dev, it fails loudly first).
+- Data flows through one visible path — RSC fetch → provider props → cache — instead of an implicit dehydrate/hydrate handoff, so the failure mode is a type error rather than a runtime one.
+- The trade: no streaming/`Suspense`-driven progressive fill. Pages await their data before rendering. For these routes the data is small and the seed removes a loading flash, so this is a win.

--- a/src/app/chat/chat-initial-data.test.tsx
+++ b/src/app/chat/chat-initial-data.test.tsx
@@ -1,0 +1,46 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { api } from '~/trpc/react'
+import { QueryHarness } from '~/lib/query-harness'
+import {
+  ChatInitialDataProvider,
+  type ChatInitialData
+} from './chat-initial-data'
+
+const userId = 'u1'
+
+const seed: ChatInitialData = {
+  tasteProfile: null,
+  filters: [{ id: 'f1', name: 'vegan', checked: true }],
+  pantry: { id: 'p1', ingredients: [] }
+} as unknown as ChatInitialData
+
+/** Mirrors what `/chat`'s welcome surfaces read on first paint. */
+function ShowChatData() {
+  const profile = api.tasteProfile.get.useQuery()
+  const filters = api.filters.getByUserId.useQuery({ userId })
+  const [pantry] = api.pantry.byUserId.useSuspenseQuery({ userId })
+  return (
+    <div>
+      seeded: {profile.isPending ? 'pending' : String(profile.data)}/
+      {filters.data?.[0]?.name}/{pantry?.id}
+    </div>
+  )
+}
+
+describe('ChatInitialDataProvider (#590)', () => {
+  it('renders every chat query from seeded data on first paint, with no requests', () => {
+    const onOp = jest.fn()
+    render(
+      <QueryHarness onOp={onOp}>
+        <ChatInitialDataProvider userId={userId} data={seed}>
+          <ShowChatData />
+        </ChatInitialDataProvider>
+      </QueryHarness>
+    )
+
+    // Synchronous: no loading flash, no suspense fallback, no round trip.
+    expect(screen.getByText('seeded: null/vegan/p1')).toBeInTheDocument()
+    expect(onOp).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/chat/chat-initial-data.tsx
+++ b/src/app/chat/chat-initial-data.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { api, type RouterOutputs } from '~/trpc/react'
+import { useSeedQueryCache } from '~/hooks/use-seed-query-cache'
+
+export type ChatInitialData = {
+  tasteProfile: RouterOutputs['tasteProfile']['get']
+  filters: RouterOutputs['filters']['getByUserId']
+  pantry: RouterOutputs['pantry']['byUserId']
+}
+
+/**
+ * Seeds the queries `<ChatWelcome>` reads — the taste profile (which is `null`
+ * for a brand-new user, and is what auto-opens the quiz), the user's filters and
+ * the pantry — with data the page fetched in its authenticated RSC.
+ *
+ * Without the seed each surface fires its own request after mount and flashes a
+ * loading state in, and the pantry's `useSuspenseQuery` would fetch during the
+ * server-render pass without a session cookie (#590). See
+ * {@link useSeedQueryCache}.
+ */
+export function ChatInitialDataProvider({
+  userId,
+  data,
+  children
+}: {
+  userId: string
+  data: ChatInitialData
+  children: React.ReactNode
+}) {
+  const utils = api.useUtils()
+  useSeedQueryCache(() => {
+    utils.tasteProfile.get.setData(undefined, data.tasteProfile)
+    utils.filters.getByUserId.setData({ userId }, data.filters)
+    utils.pantry.byUserId.setData({ userId }, data.pantry)
+  })
+  return <>{children}</>
+}

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,8 +1,9 @@
 import { redirect } from 'next/navigation'
 import { auth } from '~/server/auth'
-import { HydrateClient, api } from '~/trpc/server'
+import { api } from '~/trpc/server'
 import { RECIPES_CONTEXT } from '~/schemas/chats-schema'
 import { Chat } from '../chat'
+import { ChatInitialDataProvider } from './chat-initial-data'
 
 export default async function ChatPage() {
   const session = await auth()
@@ -11,28 +12,33 @@ export default async function ChatPage() {
   }
 
   // No profile redirect: first-run onboarding is an in-app overlay now. The
-  // taste-profile prefetch seeds `tasteProfile.get` (which returns null for a
-  // brand-new user), and TasteProfileDrawer auto-opens the quiz from that.
-  // Seed the taste-profile, filters, and pantry queries into the RSC cache so
-  // <ChatWelcome>'s summary, filters, and pantry-toggle sections render from
-  // hydrated data on first paint instead of firing their own client requests
-  // and flashing loading states in (staggered) after the page mounts.
+  // taste profile (null for a brand-new user) is what TasteProfileDrawer opens
+  // the quiz from.
+  //
+  // Fetch in this authenticated RSC and seed the client cache during render
+  // (see ChatInitialDataProvider) so <ChatWelcome>'s summary, filters and
+  // pantry-toggle sections render from real data on first paint instead of
+  // firing their own client requests and flashing loading states in
+  // (staggered) after the page mounts.
   //
   // The chat + its messages resolve together so `useResumeChat` can seed both
   // queries before the client tree renders — otherwise `chatId` and `messages`
   // land in the store on different renders, racing whatever chat surface (e.g.
   // a recipe-detail chat) was mounted before this navigation and leaving the
   // page stuck on its loading state.
-  const [, , , seed] = await Promise.all([
-    api.tasteProfile.get.prefetch(),
-    api.filters.getByUserId.prefetch({ userId: session.user.id }),
-    api.pantry.byUserId.prefetch({ userId: session.user.id }),
+  const [tasteProfile, filters, pantry, seed] = await Promise.all([
+    api.tasteProfile.get(),
+    api.filters.getByUserId({ userId: session.user.id }),
+    api.pantry.byUserId({ userId: session.user.id }),
     api.chats.getResumableChatWithMessages({ context: RECIPES_CONTEXT })
   ])
 
   return (
-    <HydrateClient>
+    <ChatInitialDataProvider
+      userId={session.user.id}
+      data={{ tasteProfile, filters, pantry }}
+    >
       <Chat seed={seed} />
-    </HydrateClient>
+    </ChatInitialDataProvider>
   )
 }

--- a/src/app/lists/lists-initial-data.test.tsx
+++ b/src/app/lists/lists-initial-data.test.tsx
@@ -1,0 +1,79 @@
+import '@testing-library/jest-dom'
+import { screen } from '@testing-library/react'
+import { Suspense } from 'react'
+import { QueryHarness } from '~/lib/query-harness'
+import { renderWithTranslations } from '~/lib/test-translations'
+
+const userId = 'u1'
+
+// `useUserId` reads this, and its result becomes part of the query key — the
+// one thing a hand-written mirror of the queries could never get wrong.
+jest.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { user: { id: 'u1' } }, status: 'authenticated' })
+}))
+
+// Imported after the mock so the components pick it up.
+import {
+  ListsInitialDataProvider,
+  type ListsInitialData
+} from './lists-initial-data'
+import { ListByUserId } from '~/app/list/list-by-user-id'
+import { PantryByUserId } from '~/app/pantry/pantry-by-user-id'
+
+const seed: ListsInitialData = {
+  groceryList: {
+    ingredients: [{ id: 'i1', rawString: 'eggs', checked: false }]
+  },
+  pantry: { id: 'p1', ingredients: [{ id: 'i2', rawString: 'flour' }] },
+  user: { id: userId, preferredWeightUnit: null, preferredVolumeUnit: null }
+} as unknown as ListsInitialData
+
+function ListsSurfaces() {
+  return (
+    <>
+      <ListByUserId />
+      <PantryByUserId />
+    </>
+  )
+}
+
+describe('ListsInitialDataProvider (#590)', () => {
+  it('renders the real /lists surfaces from seeded data, with no requests', async () => {
+    const onOp = jest.fn()
+    renderWithTranslations(
+      <QueryHarness onOp={onOp}>
+        <ListsInitialDataProvider userId={userId} data={seed}>
+          <Suspense fallback={<div>loading</div>}>
+            <ListsSurfaces />
+          </Suspense>
+        </ListsInitialDataProvider>
+      </QueryHarness>
+    )
+
+    expect(await screen.findByText('eggs')).toBeInTheDocument()
+    expect(await screen.findByText('flour')).toBeInTheDocument()
+    // The whole point: no unauthenticated server-render round trip.
+    expect(onOp).not.toHaveBeenCalled()
+  })
+
+  it('fetches when the provider is absent (guards against regressing the seed)', async () => {
+    const onOp = jest.fn()
+    renderWithTranslations(
+      <QueryHarness
+        onOp={onOp}
+        responses={{
+          'lists.byUserId': seed.groceryList,
+          'pantry.byUserId': seed.pantry,
+          'users.get': seed.user
+        }}
+      >
+        <Suspense fallback={<div>loading</div>}>
+          <ListsSurfaces />
+        </Suspense>
+      </QueryHarness>
+    )
+
+    expect(await screen.findByText('eggs')).toBeInTheDocument()
+    expect(onOp).toHaveBeenCalledWith('lists.byUserId')
+  })
+})

--- a/src/app/lists/lists-initial-data.tsx
+++ b/src/app/lists/lists-initial-data.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { api, type RouterOutputs } from '~/trpc/react'
+import { useSeedQueryCache } from '~/hooks/use-seed-query-cache'
+
+export type ListsInitialData = {
+  /** `lists.byUserId` is the legacy spelling of the Grocery List. */
+  groceryList: RouterOutputs['lists']['byUserId']
+  pantry: RouterOutputs['pantry']['byUserId']
+  user: RouterOutputs['users']['get']
+}
+
+/**
+ * Seeds the three queries `/lists` renders from — the Grocery List, the Pantry
+ * (both tabs are fetched so switching is instant) and the user's preferred
+ * units — with the data the page already fetched in its authenticated RSC.
+ *
+ * All three are read with `useSuspenseQuery`, so the cache must be warm before
+ * the children render; see {@link useSeedQueryCache} (#590).
+ */
+export function ListsInitialDataProvider({
+  userId,
+  data,
+  children
+}: {
+  userId: string
+  data: ListsInitialData
+  children: React.ReactNode
+}) {
+  const utils = api.useUtils()
+  useSeedQueryCache(() => {
+    utils.lists.byUserId.setData({ userId }, data.groceryList)
+    utils.pantry.byUserId.setData({ userId }, data.pantry)
+    utils.users.get.setData(undefined, data.user)
+  })
+  return <>{children}</>
+}

--- a/src/app/lists/page.tsx
+++ b/src/app/lists/page.tsx
@@ -1,9 +1,10 @@
-import React, { Suspense } from 'react'
-import { HydrateClient, api } from '~/trpc/server'
+import React from 'react'
+import { api } from '~/trpc/server'
 import { auth } from '~/server/auth'
 import { redirect } from 'next/navigation'
 import { ChatPanel } from '~/components/chat-panel'
 import { ListsView } from './lists-view'
+import { ListsInitialDataProvider } from './lists-initial-data'
 
 export default async function ListsPage() {
   const session = await auth()
@@ -11,22 +12,25 @@ export default async function ListsPage() {
     return redirect('/recipes')
   }
 
-  // Prefetch BOTH surfaces so switching tabs is instant with no loading flash.
-  await Promise.all([
-    api.lists.byUserId.prefetch({ userId: session.user.id }),
-    api.pantry.byUserId.prefetch({ userId: session.user.id }),
-    api.users.get.prefetch()
+  // Fetch BOTH surfaces in this authenticated RSC so switching tabs is instant
+  // with no loading flash, then hand them to the client tree as seeded query
+  // data. Prefetch + `HydrateClient` doesn't work here: the client components
+  // read with `useSuspenseQuery`, which runs during the server-render pass and
+  // refetches over HTTP without the session cookie, throwing `UNAUTHORIZED`
+  // (#590, same root cause as #545).
+  const [groceryList, pantry, user] = await Promise.all([
+    api.lists.byUserId({ userId: session.user.id }),
+    api.pantry.byUserId({ userId: session.user.id }),
+    api.users.get()
   ])
 
   return (
-    <HydrateClient>
-      {/* Load-bearing: ListByUserId/PantryByUserId call `useSuspenseQuery`,
-          which suspends on the server render pass. Without this boundary that
-          suspension bubbles past the page. */}
-      <Suspense>
-        <ListsView />
-      </Suspense>
+    <ListsInitialDataProvider
+      userId={session.user.id}
+      data={{ groceryList, pantry, user }}
+    >
+      <ListsView />
       <ChatPanel />
-    </HydrateClient>
+    </ListsInitialDataProvider>
   )
 }

--- a/src/app/parser-test/page.tsx
+++ b/src/app/parser-test/page.tsx
@@ -1,4 +1,3 @@
-import { HydrateClient } from '~/trpc/server'
 import { auth } from '~/server/auth'
 import { redirect } from 'next/navigation'
 import { ParserTestClient } from './parser-test-client'
@@ -10,19 +9,16 @@ export default async function ParserTestPage() {
   }
 
   return (
-    <HydrateClient>
-      <main className='mx-auto max-w-4xl p-6'>
-        <h1 className='text-foreground mb-4 text-2xl font-bold'>
-          Ingredient parser test
-        </h1>
-        <p className='text-muted-foreground mb-4 text-sm'>
-          All your ingredients with parsed fields. Open DevTools → Network, find
-          the{' '}
-          <code className='bg-muted rounded px-1'>getParsedIngredients</code>{' '}
-          request to see the raw JSON.
-        </p>
-        <ParserTestClient />
-      </main>
-    </HydrateClient>
+    <main className='mx-auto max-w-4xl p-6'>
+      <h1 className='text-foreground mb-4 text-2xl font-bold'>
+        Ingredient parser test
+      </h1>
+      <p className='text-muted-foreground mb-4 text-sm'>
+        All your ingredients with parsed fields. Open DevTools → Network, find
+        the <code className='bg-muted rounded px-1'>getParsedIngredients</code>{' '}
+        request to see the raw JSON.
+      </p>
+      <ParserTestClient />
+    </main>
   )
 }

--- a/src/app/recipes/infinite-recipes.tsx
+++ b/src/app/recipes/infinite-recipes.tsx
@@ -6,9 +6,7 @@ import { api } from '~/trpc/react'
 import { useInView } from 'react-intersection-observer'
 import { Recipes } from './recipes'
 import { useRecipesStore } from './recipes-store'
-
-/** On a desktop the user sees 12 at most. */
-const RECIPES_PER_PAGE_LIMIT = 12
+import { RECIPES_PER_PAGE_LIMIT } from './recipes-constants'
 
 export default function InfiniteRecipes() {
   const { ref: inViewRef, inView } = useInView()

--- a/src/app/recipes/page.tsx
+++ b/src/app/recipes/page.tsx
@@ -1,10 +1,10 @@
-import { HydrateClient, api } from '~/trpc/server'
+import { api } from '~/trpc/server'
 import InfiniteRecipes from './infinite-recipes'
 import { auth } from '~/server/auth'
 import { redirect } from 'next/navigation'
 import { RecipesAddFab } from './recipes-add-fab'
-
-const RECIPES_PER_PAGE_LIMIT = 10
+import { RecipesInitialDataProvider } from './recipes-initial-data'
+import { RECIPES_PER_PAGE_LIMIT } from './recipes-constants'
 
 export default async function RecipesView() {
   const session = await auth()
@@ -12,18 +12,21 @@ export default async function RecipesView() {
     return redirect('/')
   }
 
-  // Prefetch infinite query data into React Query cache
-  await api.recipes.infiniteRecipes.prefetchInfinite({
+  // Fetch the first page here (authenticated RSC) and seed it into the client
+  // cache during render — `InfiniteRecipes` reads it with
+  // `useSuspenseInfiniteQuery`, which otherwise refetches during the
+  // server-render pass with no session cookie and throws `UNAUTHORIZED` (#590).
+  const firstPage = await api.recipes.infiniteRecipes({
     limit: RECIPES_PER_PAGE_LIMIT,
     search: ''
   })
 
   return (
-    <HydrateClient>
+    <RecipesInitialDataProvider firstPage={firstPage}>
       <div className='mx-auto flex min-h-0 w-full flex-1 flex-col pt-3 sm:pt-4'>
         <InfiniteRecipes />
       </div>
       <RecipesAddFab />
-    </HydrateClient>
+    </RecipesInitialDataProvider>
   )
 }

--- a/src/app/recipes/recipes-constants.ts
+++ b/src/app/recipes/recipes-constants.ts
@@ -1,0 +1,8 @@
+/**
+ * Page size for `recipes.infiniteRecipes`. Shared by the RSC that fetches the
+ * first page and the client query that reads it — the value is part of the
+ * query key, so a mismatch silently misses the seeded cache entry (#590).
+ *
+ * On a desktop the user sees 12 at most.
+ */
+export const RECIPES_PER_PAGE_LIMIT = 12

--- a/src/app/recipes/recipes-initial-data.test.tsx
+++ b/src/app/recipes/recipes-initial-data.test.tsx
@@ -1,0 +1,59 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { Suspense } from 'react'
+import { api } from '~/trpc/react'
+import { QueryHarness } from '~/lib/query-harness'
+import {
+  RecipesInitialDataProvider,
+  type RecipesFirstPage
+} from './recipes-initial-data'
+import { RECIPES_PER_PAGE_LIMIT } from './recipes-constants'
+
+const firstPage = {
+  items: [{ id: 'r1', name: 'Pasta' }],
+  nextCursor: 'r2'
+} as unknown as RecipesFirstPage
+
+/** Mirrors InfiniteRecipes' query — same input, same limit constant. */
+function ShowRecipes() {
+  const [data] = api.recipes.infiniteRecipes.useSuspenseInfiniteQuery(
+    { limit: RECIPES_PER_PAGE_LIMIT, search: '' },
+    { getNextPageParam: (lastPage) => lastPage.nextCursor }
+  )
+  return <div>seeded: {data.pages[0]?.items[0]?.name}</div>
+}
+
+describe('RecipesInitialDataProvider (#590)', () => {
+  it('resolves the suspense infinite query from seeded data, with no requests', async () => {
+    const onOp = jest.fn()
+    render(
+      <QueryHarness onOp={onOp}>
+        <RecipesInitialDataProvider firstPage={firstPage}>
+          <Suspense fallback={<div>loading</div>}>
+            <ShowRecipes />
+          </Suspense>
+        </RecipesInitialDataProvider>
+      </QueryHarness>
+    )
+
+    expect(await screen.findByText('seeded: Pasta')).toBeInTheDocument()
+    expect(onOp).not.toHaveBeenCalled()
+  })
+
+  it('fetches when the provider is absent (guards against regressing the seed)', async () => {
+    const onOp = jest.fn()
+    render(
+      <QueryHarness
+        onOp={onOp}
+        responses={{ 'recipes.infiniteRecipes': firstPage }}
+      >
+        <Suspense fallback={<div>loading</div>}>
+          <ShowRecipes />
+        </Suspense>
+      </QueryHarness>
+    )
+
+    expect(await screen.findByText('seeded: Pasta')).toBeInTheDocument()
+    expect(onOp).toHaveBeenCalledWith('recipes.infiniteRecipes')
+  })
+})

--- a/src/app/recipes/recipes-initial-data.tsx
+++ b/src/app/recipes/recipes-initial-data.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { api, type RouterOutputs } from '~/trpc/react'
+import { useSeedQueryCache } from '~/hooks/use-seed-query-cache'
+import { RECIPES_PER_PAGE_LIMIT } from './recipes-constants'
+
+export type RecipesFirstPage = RouterOutputs['recipes']['infiniteRecipes']
+
+/**
+ * Seeds the first page of `recipes.infiniteRecipes` — the one `InfiniteRecipes`
+ * reads with `useSuspenseInfiniteQuery` — from the authenticated RSC fetch.
+ *
+ * The seeded input must match the client's exactly (same limit, and the empty
+ * search the store starts with), or the query misses the cache and fetches. The
+ * page param is `null`, tRPC's initial cursor; later pages come from
+ * `getNextPageParam` in the browser as usual. See {@link useSeedQueryCache}.
+ */
+export function RecipesInitialDataProvider({
+  firstPage,
+  children
+}: {
+  firstPage: RecipesFirstPage
+  children: React.ReactNode
+}) {
+  const utils = api.useUtils()
+  useSeedQueryCache(() => {
+    utils.recipes.infiniteRecipes.setInfiniteData(
+      { limit: RECIPES_PER_PAGE_LIMIT, search: '' },
+      { pages: [firstPage], pageParams: [null] }
+    )
+  })
+  return <>{children}</>
+}

--- a/src/hooks/use-recipe.test.tsx
+++ b/src/hooks/use-recipe.test.tsx
@@ -1,9 +1,7 @@
 import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
 import { Suspense, type ReactNode } from 'react'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { observable } from '@trpc/server/observable'
-import { api } from '~/trpc/react'
+import { QueryHarness } from '~/lib/query-harness'
 import {
   RecipeInitialDataProvider,
   useRecipe,
@@ -26,13 +24,6 @@ const recipe = {
   instructions: []
 } as unknown as RecipeByIdData
 
-/**
- * Renders `children` against a real React Query cache wired to a tRPC client
- * whose single terminal link records every operation and answers with the
- * canned recipe. `onOp` therefore fires once per genuine `recipes.bySlug`
- * network request — the exact thing #545 was about (an unauthenticated
- * server-render refetch). Seeding should drive that count to zero.
- */
 function Harness({
   children,
   onOp
@@ -40,26 +31,10 @@ function Harness({
   children: ReactNode
   onOp: (path: string) => void
 }) {
-  const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, staleTime: 30 * 1000 } }
-  })
-  const trpcClient = api.createClient({
-    links: [
-      () =>
-        ({ op }) =>
-          observable((observer) => {
-            onOp(op.path)
-            observer.next({ result: { data: recipe } })
-            observer.complete()
-          })
-    ]
-  })
   return (
-    <QueryClientProvider client={queryClient}>
-      <api.Provider client={trpcClient} queryClient={queryClient}>
-        {children}
-      </api.Provider>
-    </QueryClientProvider>
+    <QueryHarness onOp={onOp} responses={{ 'recipes.bySlug': recipe }}>
+      {children}
+    </QueryHarness>
   )
 }
 

--- a/src/hooks/use-recipe.tsx
+++ b/src/hooks/use-recipe.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { toast } from '~/components/toast'
 import { api, type RouterOutputs } from '~/trpc/react'
+import { useSeedQueryCache } from './use-seed-query-cache'
 
 export function useDebounce(value: string, delay = 500) {
   const [debouncedValue, setDebouncedValue] = useState(value)
@@ -27,16 +28,8 @@ export type RecipeByIdData = NonNullable<RecipeById>
 
 /**
  * Seeds the client `recipes.bySlug` query cache with the recipe the page already
- * fetched on the server, before any consumer renders.
- *
- * `useRecipe` uses `useSuspenseQuery`, which runs during the server-render (SSR)
- * pass of these client components. With an empty cache it fires an HTTP request
- * to `/api/trpc` that carries no session cookie and fails the protected-procedure
- * auth check with `UNAUTHORIZED` (#545). Writing the recipe with `setData` (as
- * opposed to a per-hook `initialData`, which React Query ignores once the query
- * already exists in the cache — e.g. after a cache-only reader ran first) marks
- * the data fresh, so the suspense query resolves synchronously on both server
- * and client and never issues that unauthenticated request.
+ * fetched on the server, before any consumer renders — see
+ * {@link useSeedQueryCache} for why the cache has to be warm this early (#545).
  */
 export function RecipeInitialDataProvider({
   slug,
@@ -48,9 +41,7 @@ export function RecipeInitialDataProvider({
   children: React.ReactNode
 }) {
   const utils = api.useUtils()
-  // Seed during render (before children mount) so the cache is warm on the very
-  // first SSR pass. `useState`'s initializer runs exactly once per mount.
-  useState(() => {
+  useSeedQueryCache(() => {
     utils.recipes.bySlug.setData({ slug }, recipe)
   })
   return <>{children}</>

--- a/src/hooks/use-seed-query-cache.test.tsx
+++ b/src/hooks/use-seed-query-cache.test.tsx
@@ -1,0 +1,58 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { Suspense } from 'react'
+import { api } from '~/trpc/react'
+import { QueryHarness } from '~/lib/query-harness'
+import { useSeedQueryCache } from './use-seed-query-cache'
+
+function Seeder({ children }: { children: React.ReactNode }) {
+  const utils = api.useUtils()
+  useSeedQueryCache(() => {
+    utils.tasteProfile.get.setData(undefined, null)
+  })
+  return <>{children}</>
+}
+
+function ShowProfile() {
+  const [profile] = api.tasteProfile.get.useSuspenseQuery()
+  return <div>profile: {profile === null ? 'none' : 'some'}</div>
+}
+
+describe('useSeedQueryCache', () => {
+  it('seeds during render, so a suspense query resolves without a request', async () => {
+    const onOp = jest.fn()
+    render(
+      <QueryHarness onOp={onOp}>
+        <Seeder>
+          <Suspense fallback={<div>loading</div>}>
+            <ShowProfile />
+          </Suspense>
+        </Seeder>
+      </QueryHarness>
+    )
+
+    expect(await screen.findByText('profile: none')).toBeInTheDocument()
+    expect(onOp).not.toHaveBeenCalled()
+  })
+
+  it('runs the seed exactly once per mount, not on every render', () => {
+    const seed = jest.fn()
+    function Probe({ n }: { n: number }) {
+      useSeedQueryCache(seed)
+      return <div>n: {n}</div>
+    }
+    const { rerender } = render(
+      <QueryHarness>
+        <Probe n={1} />
+      </QueryHarness>
+    )
+    rerender(
+      <QueryHarness>
+        <Probe n={2} />
+      </QueryHarness>
+    )
+
+    expect(screen.getByText('n: 2')).toBeInTheDocument()
+    expect(seed).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/hooks/use-seed-query-cache.ts
+++ b/src/hooks/use-seed-query-cache.ts
@@ -1,0 +1,23 @@
+'use client'
+
+import { useState } from 'react'
+
+/**
+ * Writes server-fetched data into the client query cache **during render**, once
+ * per mount, before any child of the calling component renders.
+ *
+ * This is how every page hands RSC-fetched data to its client tree (#545, #590).
+ * The timing is load-bearing: client components that call `useSuspenseQuery` run
+ * during the server-render pass, and on a cache miss they issue a real HTTP
+ * request to `/api/trpc` that carries no session cookie, so `protectedProcedure`
+ * answers `UNAUTHORIZED`. Seeding in an effect (or via `HydrateClient`) lands too
+ * late to stop that request; seeding in a `useState` initializer runs before the
+ * children mount, so the query resolves synchronously on both passes.
+ *
+ * Use `utils.x.setData(...)` inside `seed`, not a per-hook `initialData` — React
+ * Query ignores `initialData` once the query already exists in the cache.
+ */
+export function useSeedQueryCache(seed: () => void) {
+  // `useState`'s initializer runs exactly once per mount, during render.
+  useState(seed)
+}

--- a/src/lib/query-harness.tsx
+++ b/src/lib/query-harness.tsx
@@ -1,0 +1,46 @@
+import { type ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { observable } from '@trpc/server/observable'
+import { api } from '~/trpc/react'
+
+/**
+ * Renders `children` against a real React Query cache wired to a tRPC client
+ * whose single terminal link records every operation and answers it from
+ * `responses` (keyed by procedure path).
+ *
+ * `onOp` therefore fires once per genuine network request — the exact thing
+ * #545/#590 are about (an unauthenticated server-render refetch of a protected
+ * procedure). A page that seeds its caches correctly should drive that count to
+ * zero.
+ */
+export function QueryHarness({
+  children,
+  onOp,
+  responses = {}
+}: {
+  children: ReactNode
+  onOp?: (path: string) => void
+  responses?: Record<string, unknown>
+}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 30 * 1000 } }
+  })
+  const trpcClient = api.createClient({
+    links: [
+      () =>
+        ({ op }) =>
+          observable((observer) => {
+            onOp?.(op.path)
+            observer.next({ result: { data: responses[op.path] ?? null } })
+            observer.complete()
+          })
+    ]
+  })
+  return (
+    <QueryClientProvider client={queryClient}>
+      <api.Provider client={trpcClient} queryClient={queryClient}>
+        {children}
+      </api.Provider>
+    </QueryClientProvider>
+  )
+}

--- a/src/trpc/react.tsx
+++ b/src/trpc/react.tsx
@@ -9,6 +9,7 @@ import SuperJSON from 'superjson'
 
 import { type AppRouter } from '~/server/api/routers/root'
 import { createQueryClient } from './query-client'
+import { createServerRenderGuardLink } from './server-render-guard-link'
 
 let clientQueryClientSingleton: QueryClient | undefined = undefined
 const getQueryClient = () => {
@@ -49,6 +50,11 @@ export function TRPCReactProvider(props: { children: React.ReactNode }) {
             process.env.NODE_ENV === 'development' ||
             (op.direction === 'down' && op.result instanceof Error)
         }),
+        // Dev-only: turn an unseeded server-render query into a named error
+        // instead of a mystifying UNAUTHORIZED (#590).
+        ...(process.env.NODE_ENV === 'development'
+          ? [createServerRenderGuardLink()]
+          : []),
         httpBatchStreamLink({
           transformer: SuperJSON,
           url: getBaseUrl() + '/api/trpc',

--- a/src/trpc/server-render-guard-link.test.tsx
+++ b/src/trpc/server-render-guard-link.test.tsx
@@ -1,0 +1,68 @@
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { observable } from '@trpc/server/observable'
+import { api } from '~/trpc/react'
+import {
+  createServerRenderGuardLink,
+  SERVER_RENDER_QUERY_ERROR
+} from './server-render-guard-link'
+
+function Harness({
+  isServerRender,
+  onOp
+}: {
+  isServerRender: boolean
+  onOp: jest.Mock
+}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } }
+  })
+  const trpcClient = api.createClient({
+    links: [
+      createServerRenderGuardLink(() => isServerRender),
+      () =>
+        ({ op }) =>
+          observable((observer) => {
+            onOp(op.path)
+            observer.next({ result: { data: null } })
+            observer.complete()
+          })
+    ]
+  })
+  return (
+    <QueryClientProvider client={queryClient}>
+      <api.Provider client={trpcClient} queryClient={queryClient}>
+        <ShowProfile />
+      </api.Provider>
+    </QueryClientProvider>
+  )
+}
+
+function ShowProfile() {
+  const { error, isSuccess } = api.tasteProfile.get.useQuery()
+  if (error) return <div>error: {error.message}</div>
+  return <div>{isSuccess ? 'ok' : 'pending'}</div>
+}
+
+describe('createServerRenderGuardLink (#590)', () => {
+  it('fails a server-render request loudly with a named error, before it goes out', async () => {
+    const onOp = jest.fn()
+    render(<Harness isServerRender onOp={onOp} />)
+
+    expect(
+      await screen.findByText(new RegExp(SERVER_RENDER_QUERY_ERROR))
+    ).toBeInTheDocument()
+    // Never reaches the transport: the point is to stop the cookie-less request,
+    // not to let it come back as a confusing UNAUTHORIZED.
+    expect(onOp).not.toHaveBeenCalled()
+  })
+
+  it('passes browser requests straight through', async () => {
+    const onOp = jest.fn()
+    render(<Harness isServerRender={false} onOp={onOp} />)
+
+    expect(await screen.findByText('ok')).toBeInTheDocument()
+    expect(onOp).toHaveBeenCalledWith('tasteProfile.get')
+  })
+})

--- a/src/trpc/server-render-guard-link.ts
+++ b/src/trpc/server-render-guard-link.ts
@@ -1,0 +1,38 @@
+import { TRPCClientError, type TRPCLink } from '@trpc/client'
+import { observable } from '@trpc/server/observable'
+import type { AppRouter } from '~/server/api/routers/root'
+
+export const SERVER_RENDER_QUERY_ERROR = 'ServerRenderQueryError'
+
+/**
+ * Dev-only guard that makes the #545/#590 mistake loud at the moment it happens.
+ *
+ * A client query that runs during the server-render pass (in practice:
+ * `useSuspenseQuery` against an unseeded cache) goes out over HTTP with no
+ * session cookie, so `protectedProcedure` answers `UNAUTHORIZED` — a symptom
+ * three routes' worth of debugging away from the cause. This link refuses the
+ * request instead and names it, pointing at the fix.
+ *
+ * Nothing should legitimately fetch during that pass: pages fetch in their RSC
+ * and seed the cache (`useSeedQueryCache`), and `useQuery`/mutations don't fire
+ * server-side.
+ */
+export function createServerRenderGuardLink(
+  isServerRender: () => boolean = () => typeof window === 'undefined'
+): TRPCLink<AppRouter> {
+  return () =>
+    ({ op, next }) =>
+      observable((observer) => {
+        if (isServerRender()) {
+          observer.error(
+            TRPCClientError.from(
+              new Error(
+                `${SERVER_RENDER_QUERY_ERROR}: "${op.path}" ran during the server render pass, where the request carries no session cookie and a protected procedure answers UNAUTHORIZED. Fetch it in the page's RSC and seed the cache with useSeedQueryCache instead.`
+              )
+            )
+          )
+          return
+        }
+        return next(op).subscribe(observer)
+      })
+}

--- a/src/trpc/server.ts
+++ b/src/trpc/server.ts
@@ -1,12 +1,10 @@
 import 'server-only'
 
-import { createHydrationHelpers } from '@trpc/react-query/rsc'
 import { headers } from 'next/headers'
 import { cache } from 'react'
 
-import { createCaller, type AppRouter } from '~/server/api/routers/root'
+import { createCaller } from '~/server/api/routers/root'
 import { createTRPCContext } from '~/server/api/trpc'
-import { createQueryClient } from './query-client'
 
 /**
  * This wraps the `createTRPCContext` helper and provides the required context for the tRPC API when
@@ -21,10 +19,15 @@ const createContext = cache(async () => {
   })
 })
 
-const getQueryClient = cache(createQueryClient)
-const caller = createCaller(createContext)
-
-export const { trpc: api, HydrateClient } = createHydrationHelpers<AppRouter>(
-  caller,
-  getQueryClient
-)
+/**
+ * Server-side caller: `await api.recipes.bySlug({ slug })` returns data directly.
+ *
+ * Deliberately a plain caller rather than `createHydrationHelpers`, so there is
+ * no `prefetch`/`HydrateClient` to reach for. That pattern broke three times the
+ * same way (#545, #590): client components read with `useSuspenseQuery`, which
+ * runs during the server-render pass before hydration warms the cache, so it
+ * refetches over HTTP with no session cookie and `protectedProcedure` answers
+ * `UNAUTHORIZED`. Fetch here, then seed the client cache during render — see
+ * `useSeedQueryCache` and the `*InitialDataProvider` next to each page.
+ */
+export const api = createCaller(createContext)


### PR DESCRIPTION
- Introduced `useSeedQueryCache` to seed client query cache during render, preventing unauthorized requests during server-render pass.
- Replaced `HydrateClient` and `prefetch` patterns with direct data fetching in RSC and seeding via colocated providers.
- Added `ChatInitialDataProvider`, `ListsInitialDataProvider`, and `RecipesInitialDataProvider` for managing initial data for respective pages.
- Updated tests to ensure seeded data resolves without additional requests.
- Implemented `createServerRenderGuardLink` to catch unauthorized server-render requests in development.
- Refactored various components to align with new data fetching strategy, improving performance and user experience.